### PR TITLE
feat: visualize workout records

### DIFF
--- a/src/app/(workout)/workouts/page.tsx
+++ b/src/app/(workout)/workouts/page.tsx
@@ -45,16 +45,24 @@ export default async function WorkoutsPage({
   return (
     <main className="flex flex-1 flex-col items-center bg-zinc-50 px-6 py-12 dark:bg-black">
       <div className="flex w-full max-w-3xl flex-col gap-6">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-3">
           <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">Workouts</h1>
-          <form action={startWorkout}>
-            <button
-              type="submit"
-              className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+          <div className="flex items-center gap-2">
+            <Link
+              href="/workouts/stats"
+              className="rounded-full border border-black/[.08] px-5 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-black/[.04] dark:border-white/[.145] dark:text-zinc-50 dark:hover:bg-[#1a1a1a]"
             >
-              Start workout
-            </button>
-          </form>
+              Stats
+            </Link>
+            <form action={startWorkout}>
+              <button
+                type="submit"
+                className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+              >
+                Start workout
+              </button>
+            </form>
+          </div>
         </div>
 
         {errorParam === 'start_failed' && (

--- a/src/app/(workout)/workouts/stats/ActivityHeatmap.tsx
+++ b/src/app/(workout)/workouts/stats/ActivityHeatmap.tsx
@@ -1,0 +1,125 @@
+import type { DailyCount } from './aggregate';
+
+type Props = {
+  data: DailyCount[];
+};
+
+const CELL_SIZE = 12;
+const CELL_GAP = 3;
+const PADDING_LEFT = 28;
+const PADDING_TOP = 18;
+
+function colorForCount(count: number, max: number): string {
+  if (count === 0 || max === 0) {
+    return 'fill-zinc-200 dark:fill-zinc-800';
+  }
+  const ratio = count / max;
+  if (ratio < 0.34) return 'fill-emerald-300 dark:fill-emerald-900';
+  if (ratio < 0.67) return 'fill-emerald-500 dark:fill-emerald-700';
+  return 'fill-emerald-600 dark:fill-emerald-500';
+}
+
+export default function ActivityHeatmap({ data }: Props) {
+  if (data.length === 0) {
+    return (
+      <p className="text-sm text-zinc-600 dark:text-zinc-400">No workout activity yet.</p>
+    );
+  }
+
+  const weeks: DailyCount[][] = [];
+  for (let i = 0; i < data.length; i += 7) {
+    weeks.push(data.slice(i, i + 7));
+  }
+
+  const max = data.reduce((acc, d) => Math.max(acc, d.count), 0);
+  const width = PADDING_LEFT + weeks.length * (CELL_SIZE + CELL_GAP);
+  const height = PADDING_TOP + 7 * (CELL_SIZE + CELL_GAP);
+
+  const dayLabels = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+
+  // Month labels: show the month name above the first column of each new month.
+  type MonthLabel = { x: number; label: string };
+  const monthLabels: MonthLabel[] = [];
+  let lastMonth = -1;
+  weeks.forEach((week, weekIndex) => {
+    const firstDay = week[0];
+    if (!firstDay) return;
+    const monthIndex = new Date(firstDay.date).getMonth();
+    if (monthIndex !== lastMonth) {
+      monthLabels.push({
+        x: PADDING_LEFT + weekIndex * (CELL_SIZE + CELL_GAP),
+        label: new Date(firstDay.date).toLocaleString('en-US', { month: 'short' }),
+      });
+      lastMonth = monthIndex;
+    }
+  });
+
+  const totalWorkouts = data.reduce((acc, d) => acc + d.count, 0);
+  const activeDays = data.reduce((acc, d) => (d.count > 0 ? acc + 1 : acc), 0);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between text-sm">
+        <p className="text-zinc-700 dark:text-zinc-300">
+          {totalWorkouts} workouts on {activeDays} days (last {weeks.length} weeks)
+        </p>
+        <div className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+          <span>Less</span>
+          <span className="block size-3 rounded-sm bg-zinc-200 dark:bg-zinc-800" />
+          <span className="block size-3 rounded-sm bg-emerald-300 dark:bg-emerald-900" />
+          <span className="block size-3 rounded-sm bg-emerald-500 dark:bg-emerald-700" />
+          <span className="block size-3 rounded-sm bg-emerald-600 dark:bg-emerald-500" />
+          <span>More</span>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <svg
+          width={width}
+          height={height}
+          viewBox={`0 0 ${width} ${height}`}
+          role="img"
+          aria-label="Workout activity heatmap"
+        >
+          {monthLabels.map((m) => (
+            <text
+              key={`${m.label}-${m.x}`}
+              x={m.x}
+              y={12}
+              className="fill-zinc-500 text-[10px] dark:fill-zinc-400"
+            >
+              {m.label}
+            </text>
+          ))}
+          {dayLabels.map((label, index) =>
+            label ? (
+              <text
+                key={label}
+                x={0}
+                y={PADDING_TOP + index * (CELL_SIZE + CELL_GAP) + CELL_SIZE - 2}
+                className="fill-zinc-500 text-[10px] dark:fill-zinc-400"
+              >
+                {label}
+              </text>
+            ) : null,
+          )}
+          {weeks.map((week, weekIndex) =>
+            week.map((day, dayIndex) => (
+              <rect
+                key={day.date}
+                x={PADDING_LEFT + weekIndex * (CELL_SIZE + CELL_GAP)}
+                y={PADDING_TOP + dayIndex * (CELL_SIZE + CELL_GAP)}
+                width={CELL_SIZE}
+                height={CELL_SIZE}
+                rx={2}
+                ry={2}
+                className={colorForCount(day.count, max)}
+              >
+                <title>{`${day.date}: ${day.count} workout${day.count === 1 ? '' : 's'}`}</title>
+              </rect>
+            )),
+          )}
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(workout)/workouts/stats/ActivityHeatmap.tsx
+++ b/src/app/(workout)/workouts/stats/ActivityHeatmap.tsx
@@ -48,7 +48,7 @@ export default function ActivityHeatmap({ data }: Props) {
     if (monthIndex !== lastMonth) {
       monthLabels.push({
         x: PADDING_LEFT + weekIndex * (CELL_SIZE + CELL_GAP),
-        label: new Date(firstDay.date).toLocaleString('en-US', { month: 'short' }),
+        label: new Date(firstDay.date).toLocaleString(undefined, { month: 'short' }),
       });
       lastMonth = monthIndex;
     }

--- a/src/app/(workout)/workouts/stats/VolumeChart.tsx
+++ b/src/app/(workout)/workouts/stats/VolumeChart.tsx
@@ -1,0 +1,115 @@
+import FormattedDateTime from '@/components/FormattedDateTime';
+import Link from 'next/link';
+import type { WorkoutVolume } from './aggregate';
+
+type Props = {
+  data: WorkoutVolume[];
+};
+
+const CHART_HEIGHT = 180;
+const BAR_WIDTH = 18;
+const BAR_GAP = 8;
+const PADDING_LEFT = 40;
+const PADDING_TOP = 12;
+const PADDING_BOTTOM = 20;
+
+function formatVolume(value: number): string {
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1)}k`;
+  }
+  return String(Math.round(value));
+}
+
+export default function VolumeChart({ data }: Props) {
+  if (data.length === 0) {
+    return (
+      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+        No sets recorded yet — once you log sets, your volume will show up here.
+      </p>
+    );
+  }
+
+  const max = data.reduce((acc, d) => Math.max(acc, d.volume), 0);
+  const safeMax = max === 0 ? 1 : max;
+  const chartWidth = PADDING_LEFT + data.length * (BAR_WIDTH + BAR_GAP);
+  const totalHeight = PADDING_TOP + CHART_HEIGHT + PADDING_BOTTOM;
+
+  const gridLines = [0, 0.25, 0.5, 0.75, 1];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="overflow-x-auto">
+        <svg
+          width={chartWidth}
+          height={totalHeight}
+          viewBox={`0 0 ${chartWidth} ${totalHeight}`}
+          role="img"
+          aria-label="Volume per workout"
+        >
+          {gridLines.map((ratio) => {
+            const y = PADDING_TOP + CHART_HEIGHT * (1 - ratio);
+            const value = safeMax * ratio;
+            return (
+              <g key={ratio}>
+                <line
+                  x1={PADDING_LEFT}
+                  x2={chartWidth}
+                  y1={y}
+                  y2={y}
+                  className="stroke-zinc-200 dark:stroke-zinc-800"
+                  strokeDasharray={ratio === 0 ? undefined : '2 3'}
+                />
+                <text
+                  x={PADDING_LEFT - 6}
+                  y={y + 3}
+                  textAnchor="end"
+                  className="fill-zinc-500 text-[10px] dark:fill-zinc-400"
+                >
+                  {formatVolume(value)}
+                </text>
+              </g>
+            );
+          })}
+          {data.map((entry, index) => {
+            const ratio = entry.volume / safeMax;
+            const barHeight = CHART_HEIGHT * ratio;
+            const x = PADDING_LEFT + index * (BAR_WIDTH + BAR_GAP);
+            const y = PADDING_TOP + CHART_HEIGHT - barHeight;
+            return (
+              <rect
+                key={entry.workoutId}
+                x={x}
+                y={y}
+                width={BAR_WIDTH}
+                height={Math.max(barHeight, entry.volume > 0 ? 2 : 0)}
+                rx={2}
+                ry={2}
+                className="fill-emerald-500 dark:fill-emerald-500"
+              >
+                <title>{`${entry.startedAt} — ${formatVolume(entry.volume)} (rep × kg)`}</title>
+              </rect>
+            );
+          })}
+        </svg>
+      </div>
+      <ul className="flex flex-col divide-y divide-black/[.06] text-sm dark:divide-white/[.08]">
+        {data
+          .slice()
+          .reverse()
+          .map((entry) => (
+            <li key={entry.workoutId} className="flex items-center justify-between gap-3 py-2">
+              <Link
+                href={`/workouts/${entry.workoutId}`}
+                className="text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
+              >
+                <FormattedDateTime value={entry.startedAt} />
+              </Link>
+              <span className="text-zinc-900 dark:text-zinc-50">
+                {formatVolume(entry.volume)} <span className="text-xs text-zinc-500">rep × kg</span>
+              </span>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(workout)/workouts/stats/aggregate.ts
+++ b/src/app/(workout)/workouts/stats/aggregate.ts
@@ -1,0 +1,77 @@
+import type { components as workoutSchema } from '../../../../../gen/workout/v1/workout.schema';
+
+type Workout = workoutSchema['schemas']['v1Workout'];
+type Set = workoutSchema['schemas']['v1Set'];
+
+export type DailyCount = {
+  date: string;
+  count: number;
+};
+
+export type WorkoutVolume = {
+  workoutId: string;
+  startedAt: string;
+  volume: number;
+};
+
+function toLocalDateKey(iso: string): string {
+  const date = new Date(iso);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function buildDailyCounts(workouts: Workout[], weeks: number): DailyCount[] {
+  const totalDays = weeks * 7;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const start = new Date(today);
+  start.setDate(start.getDate() - (totalDays - 1));
+  // Align the start to the previous Sunday so the grid lays out cleanly.
+  start.setDate(start.getDate() - start.getDay());
+
+  const counts = new Map<string, number>();
+  for (const workout of workouts) {
+    if (!workout.startedAt) continue;
+    const key = toLocalDateKey(workout.startedAt);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const result: DailyCount[] = [];
+  const cursor = new Date(start);
+  const end = new Date(today);
+  while (cursor <= end) {
+    const year = cursor.getFullYear();
+    const month = String(cursor.getMonth() + 1).padStart(2, '0');
+    const day = String(cursor.getDate()).padStart(2, '0');
+    const key = `${year}-${month}-${day}`;
+    result.push({ date: key, count: counts.get(key) ?? 0 });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return result;
+}
+
+export function computeWorkoutVolume(sets: Set[]): number {
+  let volume = 0;
+  for (const set of sets) {
+    const rep = set.rep ?? 0;
+    const weight = set.weight ?? 0;
+    volume += rep * weight;
+  }
+  return volume;
+}
+
+export function buildWorkoutVolumes(
+  entries: { workout: Workout; sets: Set[] }[],
+): WorkoutVolume[] {
+  return entries
+    .filter(({ workout }) => !!workout.workoutId && !!workout.startedAt)
+    .map(({ workout, sets }) => ({
+      workoutId: workout.workoutId!,
+      startedAt: workout.startedAt!,
+      volume: computeWorkoutVolume(sets),
+    }))
+    .sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
+}

--- a/src/app/(workout)/workouts/stats/aggregate.ts
+++ b/src/app/(workout)/workouts/stats/aggregate.ts
@@ -73,5 +73,5 @@ export function buildWorkoutVolumes(
       startedAt: workout.startedAt!,
       volume: computeWorkoutVolume(sets),
     }))
-    .sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
+    .sort((a, b) => a.startedAt.localeCompare(b.startedAt));
 }

--- a/src/app/(workout)/workouts/stats/page.tsx
+++ b/src/app/(workout)/workouts/stats/page.tsx
@@ -1,0 +1,123 @@
+import { client as workoutClient } from '@/app/api/workout/client';
+import { getAccessToken } from '@/lib/session';
+import Link from 'next/link';
+import type { components as workoutSchema } from '../../../../../gen/workout/v1/workout.schema';
+import ActivityHeatmap from './ActivityHeatmap';
+import VolumeChart from './VolumeChart';
+import { buildDailyCounts, buildWorkoutVolumes } from './aggregate';
+
+type Workout = workoutSchema['schemas']['v1Workout'];
+type Set = workoutSchema['schemas']['v1Set'];
+
+const HEATMAP_WEEKS = 12;
+
+export default async function WorkoutStatsPage() {
+  const accessToken = await getAccessToken();
+
+  if (!accessToken) {
+    return (
+      <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
+        <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
+          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">Workout stats</h1>
+          <p className="text-zinc-600 dark:text-zinc-400">Sign in to view your stats.</p>
+          <a
+            href="/api/auth/login"
+            className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+          >
+            Login
+          </a>
+        </div>
+      </main>
+    );
+  }
+
+  const listResult = await workoutClient.GET('/v1/workouts', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (listResult.error) {
+    return (
+      <main className="flex flex-1 flex-col items-center bg-zinc-50 px-6 py-12 dark:bg-black">
+        <div className="flex w-full max-w-3xl flex-col gap-6">
+          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">Workout stats</h1>
+          <p className="text-sm text-rose-500">Failed to load workouts.</p>
+          <Link
+            href="/workouts"
+            className="self-start text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+          >
+            ← Back to workouts
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const workouts: Workout[] = listResult.data?.workouts ?? [];
+
+  const detailResults = await Promise.all(
+    workouts
+      .filter((workout): workout is Workout & { workoutId: string } => !!workout.workoutId)
+      .map((workout) =>
+        workoutClient
+          .GET('/v1/workouts/{workoutId}', {
+            params: { path: { workoutId: workout.workoutId } },
+            headers: { Authorization: `Bearer ${accessToken}` },
+          })
+          .then((result) => ({ workout, result })),
+      ),
+  );
+
+  const detailEntries: { workout: Workout; sets: Set[] }[] = detailResults.map(
+    ({ workout, result }) => ({
+      workout: result.data?.workout ?? workout,
+      sets: result.data?.sets ?? [],
+    }),
+  );
+
+  const dailyCounts = buildDailyCounts(workouts, HEATMAP_WEEKS);
+  const workoutVolumes = buildWorkoutVolumes(detailEntries);
+  const detailFailures = detailResults.filter(({ result }) => !!result.error).length;
+
+  return (
+    <main className="flex flex-1 flex-col items-center bg-zinc-50 px-6 py-12 dark:bg-black">
+      <div className="flex w-full max-w-3xl flex-col gap-6">
+        <div className="flex items-center justify-between">
+          <Link
+            href="/workouts"
+            className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+          >
+            ← Back to workouts
+          </Link>
+          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">Workout stats</h1>
+        </div>
+
+        {workouts.length === 0 ? (
+          <p className="text-zinc-600 dark:text-zinc-400">
+            No workouts to visualize yet. Record your first workout to see your stats.
+          </p>
+        ) : (
+          <>
+            <section className="rounded-2xl border border-black/[.08] bg-white p-5 dark:border-white/[.145] dark:bg-zinc-900">
+              <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+                Activity
+              </h2>
+              <ActivityHeatmap data={dailyCounts} />
+            </section>
+
+            <section className="rounded-2xl border border-black/[.08] bg-white p-5 dark:border-white/[.145] dark:bg-zinc-900">
+              <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+                Volume per workout
+              </h2>
+              {detailFailures > 0 && (
+                <p className="mb-3 text-xs text-rose-500">
+                  Some workouts could not be loaded; volume may be incomplete.
+                </p>
+              )}
+              <VolumeChart data={workoutVolumes} />
+            </section>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/workouts/stats` page that visualizes workout history with a GitHub-style activity heatmap (last 12 weeks) and a per-workout volume chart (sum of rep × weight).
- Both charts are pure SVG with no new dependencies; chart data is fetched on every request so the page always reflects the latest workouts.
- Link to the stats page from the workouts list header.

Closes #5.

## Test plan
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] Sign in and visit `/workouts/stats` with no workouts — empty state renders.
- [ ] Record a workout with at least one set, revisit `/workouts/stats` — heatmap shows the active day and the volume chart shows the workout (clicking the row navigates to the workout detail).
- [ ] Visit `/workouts/stats` while signed out — login prompt renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)