### PR TITLE
feat: generate and display exercise images

### DIFF
--- a/public/exercises/bench_press.svg
+++ b/public/exercises/bench_press.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Bench press">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+  </style>
+  <g class="ex">
+    <rect x="48" y="184" width="160" height="12" rx="4"/>
+    <line x1="64" y1="196" x2="54" y2="226"/>
+    <line x1="192" y1="196" x2="202" y2="226"/>
+    <circle cx="188" cy="170" r="12"/>
+    <line x1="176" y1="170" x2="80" y2="170"/>
+    <line x1="80" y1="170" x2="66" y2="184"/>
+    <line x1="128" y1="170" x2="128" y2="112"/>
+    <line x1="20" y1="108" x2="236" y2="108" stroke-width="9"/>
+    <circle cx="42" cy="108" r="22"/>
+    <circle cx="214" cy="108" r="22"/>
+    <circle cx="42" cy="108" r="6"/>
+    <circle cx="214" cy="108" r="6"/>
+  </g>
+</svg>

--- a/public/exercises/bent_over_row.svg
+++ b/public/exercises/bent_over_row.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Bent over row">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+  </style>
+  <g class="ex">
+    <circle cx="56" cy="106" r="12"/>
+    <line x1="68" y1="110" x2="146" y2="126"/>
+    <line x1="146" y1="126" x2="158" y2="174"/>
+    <line x1="158" y1="174" x2="150" y2="212"/>
+    <line x1="142" y1="216" x2="170" y2="216"/>
+    <line x1="82" y1="114" x2="76" y2="68"/>
+    <line x1="76" y1="68" x2="118" y2="158"/>
+    <line x1="20" y1="160" x2="236" y2="160" stroke-width="9"/>
+    <circle cx="42" cy="160" r="22"/>
+    <circle cx="214" cy="160" r="22"/>
+    <circle cx="42" cy="160" r="6"/>
+    <circle cx="214" cy="160" r="6"/>
+    <line x1="20" y1="226" x2="236" y2="226" stroke-width="4" opacity="0.5"/>
+  </g>
+</svg>

--- a/public/exercises/deadlift.svg
+++ b/public/exercises/deadlift.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Deadlift">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+  </style>
+  <g class="ex">
+    <circle cx="62" cy="116" r="12"/>
+    <line x1="74" y1="120" x2="148" y2="140"/>
+    <line x1="148" y1="140" x2="164" y2="184"/>
+    <line x1="164" y1="184" x2="154" y2="218"/>
+    <line x1="144" y1="222" x2="174" y2="222"/>
+    <line x1="88" y1="124" x2="88" y2="200"/>
+    <line x1="20" y1="206" x2="236" y2="206" stroke-width="9"/>
+    <circle cx="42" cy="206" r="22"/>
+    <circle cx="214" cy="206" r="22"/>
+    <circle cx="42" cy="206" r="6"/>
+    <circle cx="214" cy="206" r="6"/>
+    <line x1="20" y1="230" x2="236" y2="230" stroke-width="4" opacity="0.5"/>
+  </g>
+</svg>

--- a/public/exercises/dumbbell_curl.svg
+++ b/public/exercises/dumbbell_curl.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Dumbbell curl">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+    .pl{fill:currentColor;stroke:none}
+  </style>
+  <g class="ex">
+    <circle cx="128" cy="62" r="12"/>
+    <line x1="128" y1="74" x2="128" y2="162"/>
+    <line x1="128" y1="162" x2="108" y2="222"/>
+    <line x1="128" y1="162" x2="148" y2="222"/>
+    <line x1="116" y1="88" x2="90" y2="146"/>
+    <line x1="90" y1="146" x2="108" y2="92"/>
+    <line x1="140" y1="88" x2="166" y2="146"/>
+    <line x1="166" y1="146" x2="148" y2="92"/>
+    <line x1="100" y1="92" x2="116" y2="92" stroke-width="5"/>
+    <rect class="pl" x="88" y="78" width="12" height="28" rx="3"/>
+    <rect class="pl" x="116" y="78" width="12" height="28" rx="3"/>
+    <line x1="140" y1="92" x2="156" y2="92" stroke-width="5"/>
+    <rect class="pl" x="128" y="78" width="12" height="28" rx="3"/>
+    <rect class="pl" x="156" y="78" width="12" height="28" rx="3"/>
+    <line x1="20" y1="230" x2="236" y2="230" stroke-width="4" opacity="0.5"/>
+  </g>
+</svg>

--- a/public/exercises/lat_pulldown.svg
+++ b/public/exercises/lat_pulldown.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Lat pulldown">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+  </style>
+  <g class="ex">
+    <line x1="24" y1="24" x2="232" y2="24" stroke-width="8"/>
+    <circle cx="128" cy="42" r="9"/>
+    <line x1="128" y1="51" x2="128" y2="86"/>
+    <path d="M 52 102 L 90 88 L 166 88 L 204 102"/>
+    <line x1="108" y1="124" x2="86" y2="94"/>
+    <line x1="148" y1="124" x2="170" y2="94"/>
+    <circle cx="128" cy="118" r="12"/>
+    <line x1="128" y1="130" x2="128" y2="188"/>
+    <rect x="76" y="190" width="104" height="12" rx="4"/>
+    <line x1="100" y1="202" x2="94" y2="226"/>
+    <line x1="156" y1="202" x2="162" y2="226"/>
+    <line x1="20" y1="230" x2="236" y2="230" stroke-width="4" opacity="0.5"/>
+  </g>
+</svg>

--- a/public/exercises/leg_press.svg
+++ b/public/exercises/leg_press.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Leg press">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+  </style>
+  <g class="ex">
+    <rect x="20" y="178" width="92" height="14" rx="4"/>
+    <line x1="34" y1="192" x2="26" y2="222"/>
+    <line x1="98" y1="192" x2="106" y2="222"/>
+    <line x1="22" y1="178" x2="16" y2="138"/>
+    <circle cx="38" cy="130" r="11"/>
+    <line x1="48" y1="134" x2="98" y2="170"/>
+    <line x1="98" y1="170" x2="152" y2="130"/>
+    <line x1="152" y1="130" x2="184" y2="86"/>
+    <line x1="166" y1="64" x2="200" y2="108" stroke-width="8"/>
+    <circle cx="216" cy="120" r="22"/>
+    <circle cx="194" cy="148" r="22"/>
+    <circle cx="216" cy="120" r="6"/>
+    <circle cx="194" cy="148" r="6"/>
+    <line x1="20" y1="230" x2="236" y2="230" stroke-width="4" opacity="0.5"/>
+  </g>
+</svg>

--- a/public/exercises/overhead_press.svg
+++ b/public/exercises/overhead_press.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Overhead press">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+  </style>
+  <g class="ex">
+    <line x1="20" y1="42" x2="236" y2="42" stroke-width="9"/>
+    <circle cx="42" cy="42" r="22"/>
+    <circle cx="214" cy="42" r="22"/>
+    <circle cx="42" cy="42" r="6"/>
+    <circle cx="214" cy="42" r="6"/>
+    <line x1="118" y1="94" x2="108" y2="50"/>
+    <line x1="138" y1="94" x2="148" y2="50"/>
+    <circle cx="128" cy="80" r="12"/>
+    <line x1="128" y1="92" x2="128" y2="164"/>
+    <line x1="128" y1="164" x2="108" y2="220"/>
+    <line x1="128" y1="164" x2="148" y2="220"/>
+    <line x1="20" y1="230" x2="236" y2="230" stroke-width="4" opacity="0.5"/>
+  </g>
+</svg>

--- a/public/exercises/pull_up.svg
+++ b/public/exercises/pull_up.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Pull up">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+  </style>
+  <g class="ex">
+    <line x1="16" y1="44" x2="240" y2="44" stroke-width="9"/>
+    <line x1="20" y1="20" x2="20" y2="44"/>
+    <line x1="236" y1="20" x2="236" y2="44"/>
+    <line x1="86" y1="48" x2="100" y2="92"/>
+    <line x1="170" y1="48" x2="156" y2="92"/>
+    <circle cx="128" cy="78" r="12"/>
+    <line x1="128" y1="90" x2="128" y2="170"/>
+    <line x1="128" y1="170" x2="114" y2="222"/>
+    <line x1="128" y1="170" x2="142" y2="222"/>
+  </g>
+</svg>

--- a/public/exercises/squat.svg
+++ b/public/exercises/squat.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Squat">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+  </style>
+  <g class="ex">
+    <line x1="20" y1="92" x2="236" y2="92" stroke-width="9"/>
+    <circle cx="42" cy="92" r="22"/>
+    <circle cx="214" cy="92" r="22"/>
+    <circle cx="42" cy="92" r="6"/>
+    <circle cx="214" cy="92" r="6"/>
+    <circle cx="128" cy="60" r="12"/>
+    <line x1="128" y1="72" x2="128" y2="92"/>
+    <line x1="128" y1="92" x2="140" y2="142"/>
+    <line x1="140" y1="142" x2="174" y2="170"/>
+    <line x1="174" y1="170" x2="146" y2="218"/>
+    <line x1="136" y1="222" x2="174" y2="222"/>
+    <path d="M 124 96 L 100 112"/>
+    <line x1="20" y1="230" x2="236" y2="230" stroke-width="4" opacity="0.5"/>
+  </g>
+</svg>

--- a/public/exercises/tricep_pushdown.svg
+++ b/public/exercises/tricep_pushdown.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Tricep pushdown">
+  <style>
+    svg{color:#3f3f46}
+    @media (prefers-color-scheme:dark){svg{color:#e4e4e7}}
+    .ex{fill:none;stroke:currentColor;stroke-width:6;stroke-linecap:round;stroke-linejoin:round}
+    .pl{fill:currentColor;stroke:none}
+  </style>
+  <g class="ex">
+    <line x1="28" y1="34" x2="228" y2="34" stroke-width="8"/>
+    <circle cx="128" cy="50" r="9"/>
+    <line x1="128" y1="59" x2="128" y2="108"/>
+    <path d="M 96 138 L 128 108 L 160 138"/>
+    <circle class="pl" cx="96" cy="142" r="5"/>
+    <circle class="pl" cx="160" cy="142" r="5"/>
+    <line x1="116" y1="96" x2="100" y2="140"/>
+    <line x1="140" y1="96" x2="156" y2="140"/>
+    <circle cx="128" cy="80" r="12"/>
+    <line x1="128" y1="92" x2="128" y2="166"/>
+    <line x1="128" y1="166" x2="108" y2="222"/>
+    <line x1="128" y1="166" x2="148" y2="222"/>
+    <line x1="20" y1="230" x2="236" y2="230" stroke-width="4" opacity="0.5"/>
+  </g>
+</svg>

--- a/src/app/(workout)/workouts/[workoutId]/AddSetForm.tsx
+++ b/src/app/(workout)/workouts/[workoutId]/AddSetForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useActionState, useSyncExternalStore } from 'react';
+import { useActionState, useState, useSyncExternalStore } from 'react';
+import ExerciseImage from '@/components/ExerciseImage';
 import type { components } from '../../../../../gen/exercise/v1/exercise.schema';
 import { createSet, type CreateSetFormState } from './actions';
 
@@ -32,6 +33,8 @@ export default function AddSetForm({
   exercises: Exercise[];
   disabled: boolean;
 }) {
+  const [selectedExerciseId, setSelectedExerciseId] = useState('');
+
   const boundAction = createSet.bind(null, workoutId);
   const wrappedAction = (prev: CreateSetFormState, formData: FormData) => {
     const raw = String(formData.get('trainedAt') ?? '');
@@ -48,28 +51,46 @@ export default function AddSetForm({
   const defaultTrainedAt = useSyncExternalStore(noopSubscribe, getClientNow, emptyDefault);
 
   return (
-    <form action={formAction} className="flex flex-col gap-3">
+    <form action={formAction} className="flex flex-col gap-4">
       <div>
-        <label
-          htmlFor="exerciseId"
-          className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
-        >
+        <span className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           Exercise
-        </label>
-        <select
-          id="exerciseId"
-          name="exerciseId"
-          required
-          disabled={disabled || exercises.length === 0}
-          className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-zinc-900 outline-none focus:border-zinc-400 disabled:opacity-50 dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
-        >
-          <option value="">Select exercise…</option>
-          {exercises.map((exercise) => (
-            <option key={exercise.exerciseId} value={exercise.exerciseId ?? ''}>
-              {exercise.name ?? exercise.code ?? exercise.exerciseId}
-            </option>
-          ))}
-        </select>
+        </span>
+        <input type="hidden" name="exerciseId" value={selectedExerciseId} />
+        {exercises.length === 0 ? (
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">No exercises available.</p>
+        ) : (
+          <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {exercises.map((exercise) => {
+              const id = exercise.exerciseId ?? '';
+              const isSelected = id !== '' && selectedExerciseId === id;
+              return (
+                <li key={id || exercise.code}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedExerciseId(id)}
+                    disabled={disabled || !id}
+                    aria-pressed={isSelected}
+                    className={`flex w-full flex-col items-center gap-1 rounded-xl border p-2 text-center transition-colors disabled:opacity-50 ${
+                      isSelected
+                        ? 'border-foreground bg-zinc-100 dark:border-zinc-200 dark:bg-zinc-800'
+                        : 'border-black/[.08] bg-white hover:bg-zinc-50 dark:border-white/[.145] dark:bg-zinc-950 dark:hover:bg-zinc-900'
+                    }`}
+                  >
+                    <ExerciseImage
+                      code={exercise.code}
+                      name={exercise.name ?? exercise.code}
+                      className="h-16 w-16"
+                    />
+                    <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
+                      {exercise.name ?? exercise.code ?? id}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
         {state.fieldErrors?.exerciseId && (
           <p className="mt-1 text-sm text-rose-500">{state.fieldErrors.exerciseId}</p>
         )}

--- a/src/app/(workout)/workouts/[workoutId]/AddSetForm.tsx
+++ b/src/app/(workout)/workouts/[workoutId]/AddSetForm.tsx
@@ -52,10 +52,10 @@ export default function AddSetForm({
 
   return (
     <form action={formAction} className="flex flex-col gap-4">
-      <div>
-        <span className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+      <fieldset disabled={disabled}>
+        <legend className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           Exercise
-        </span>
+        </legend>
         <input type="hidden" name="exerciseId" value={selectedExerciseId} />
         {exercises.length === 0 ? (
           <p className="text-sm text-zinc-500 dark:text-zinc-400">No exercises available.</p>
@@ -69,7 +69,7 @@ export default function AddSetForm({
                   <button
                     type="button"
                     onClick={() => setSelectedExerciseId(id)}
-                    disabled={disabled || !id}
+                    disabled={!id}
                     aria-pressed={isSelected}
                     className={`flex w-full flex-col items-center gap-1 rounded-xl border p-2 text-center transition-colors disabled:opacity-50 ${
                       isSelected
@@ -94,7 +94,7 @@ export default function AddSetForm({
         {state.fieldErrors?.exerciseId && (
           <p className="mt-1 text-sm text-rose-500">{state.fieldErrors.exerciseId}</p>
         )}
-      </div>
+      </fieldset>
 
       <div className="grid grid-cols-2 gap-3">
         <div>
@@ -166,7 +166,7 @@ export default function AddSetForm({
 
       <button
         type="submit"
-        disabled={disabled || isPending}
+        disabled={disabled || isPending || !selectedExerciseId}
         className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
       >
         {isPending ? 'Recording…' : 'Add set'}

--- a/src/app/(workout)/workouts/[workoutId]/page.tsx
+++ b/src/app/(workout)/workouts/[workoutId]/page.tsx
@@ -1,5 +1,6 @@
 import { client as exerciseClient } from '@/app/api/exercise/client';
 import { client as workoutClient } from '@/app/api/workout/client';
+import ExerciseImage from '@/components/ExerciseImage';
 import FormattedDateTime from '@/components/FormattedDateTime';
 import { getAccessToken } from '@/lib/session';
 import Link from 'next/link';
@@ -11,6 +12,11 @@ import { finishWorkout } from './actions';
 type Workout = workoutSchema['schemas']['v1Workout'];
 type Set = workoutSchema['schemas']['v1Set'];
 type Exercise = exerciseSchema['schemas']['v1Exercise'];
+
+function exerciseFor(set: Set, byId: Map<string, Exercise>): Exercise | undefined {
+  if (!set.exerciseId) return undefined;
+  return byId.get(set.exerciseId);
+}
 
 function exerciseLabel(set: Set, byId: Map<string, Exercise>): string {
   if (!set.exerciseId) return 'Unknown exercise';
@@ -126,22 +132,22 @@ export default async function WorkoutDetailPage({
             <p className="text-sm text-zinc-600 dark:text-zinc-400">No sets recorded yet.</p>
           ) : (
             <ul className="flex flex-col divide-y divide-black/[.06] dark:divide-white/[.08]">
-              {sets.map((set) => (
-                <li
-                  key={set.setId}
-                  className="flex items-center justify-between gap-3 py-2 text-sm"
-                >
-                  <span className="text-zinc-900 dark:text-zinc-50">
-                    {exerciseLabel(set, exerciseById)}
-                  </span>
-                  <span className="text-zinc-600 dark:text-zinc-400">
-                    {set.rep ?? 0} reps × {set.weight ?? 0} kg
-                  </span>
-                  <span className="text-xs text-zinc-500 dark:text-zinc-500">
-                    <FormattedDateTime value={set.trainedAt} />
-                  </span>
-                </li>
-              ))}
+              {sets.map((set) => {
+                const exercise = exerciseFor(set, exerciseById);
+                const label = exerciseLabel(set, exerciseById);
+                return (
+                  <li key={set.setId} className="flex items-center gap-3 py-2 text-sm">
+                    <ExerciseImage code={exercise?.code} name={label} className="h-12 w-12" />
+                    <span className="flex-1 text-zinc-900 dark:text-zinc-50">{label}</span>
+                    <span className="text-zinc-600 dark:text-zinc-400">
+                      {set.rep ?? 0} reps × {set.weight ?? 0} kg
+                    </span>
+                    <span className="text-xs text-zinc-500 dark:text-zinc-500">
+                      <FormattedDateTime value={set.trainedAt} />
+                    </span>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </section>

--- a/src/components/ExerciseImage.tsx
+++ b/src/components/ExerciseImage.tsx
@@ -1,0 +1,60 @@
+import Image from 'next/image';
+
+const EXERCISE_IMAGE_CODES = new Set([
+  'bench_press',
+  'squat',
+  'deadlift',
+  'overhead_press',
+  'bent_over_row',
+  'pull_up',
+  'lat_pulldown',
+  'leg_press',
+  'dumbbell_curl',
+  'tricep_pushdown',
+]);
+
+export default function ExerciseImage({
+  code,
+  name,
+  className,
+}: {
+  code?: string;
+  name?: string;
+  className?: string;
+}) {
+  const baseClass =
+    'shrink-0 rounded-lg bg-zinc-100 object-contain dark:bg-zinc-800 ' + (className ?? '');
+
+  if (code && EXERCISE_IMAGE_CODES.has(code)) {
+    return (
+      <Image
+        src={`/exercises/${code}.svg`}
+        alt={name ?? code}
+        width={64}
+        height={64}
+        className={baseClass}
+        unoptimized
+      />
+    );
+  }
+
+  return (
+    <div
+      role="img"
+      aria-label={name ?? 'Exercise'}
+      className={`flex items-center justify-center text-zinc-400 dark:text-zinc-500 ${baseClass}`}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        className="h-1/2 w-1/2"
+      >
+        <circle cx="6" cy="12" r="2" />
+        <rect x="9" y="9" width="6" height="6" rx="1" />
+        <circle cx="18" cy="12" r="2" />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add SVG image assets for every exercise served by the workout service (10 in total) under `public/exercises/{code}.svg`.
- Add a reusable `ExerciseImage` component that resolves an exercise `code` to its asset and falls back to a neutral placeholder for unknown codes.
- Surface exercise images in the workout detail set list and replace the native `<select>` in the add-set form with a responsive image-and-name grid picker.

Closes #7

## Test plan
- [ ] `npm run lint` is clean.
- [ ] `npm run build` succeeds.
- [ ] Open `/workouts/{workoutId}` and confirm each recorded set shows the matching exercise icon.
- [ ] In the add-set form, confirm every exercise appears as a card with its image, that selecting a card highlights it, and that submitting records the selected exercise.
- [ ] Toggle the OS color scheme and confirm the icons adapt to light/dark mode.
- [ ] Confirm the placeholder fallback renders if a set references an exercise whose code has no asset.