### PR TITLE
Responsive design across all screen sizes (#16)

### DIFF
--- a/src/app/[lang]/(user)/register/RegisterForm.tsx
+++ b/src/app/[lang]/(user)/register/RegisterForm.tsx
@@ -18,8 +18,8 @@ export default function RegisterForm({
   const [state, formAction, isPending] = useActionState(boundAction, initialState);
 
   return (
-    <div className="mx-auto mt-12 max-w-lg rounded-2xl border border-black/[.08] bg-white p-8 dark:border-white/[.145] dark:bg-zinc-900">
-      <h1 className="mb-6 text-center text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
+    <div className="mx-auto mt-8 w-full max-w-lg rounded-2xl border border-black/[.08] bg-white p-5 sm:mt-12 sm:p-8 dark:border-white/[.145] dark:bg-zinc-900">
+      <h1 className="mb-6 text-center text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">
         {dict.title}
       </h1>
       <form action={formAction} className="space-y-4">
@@ -34,8 +34,9 @@ export default function RegisterForm({
             id="displayName"
             name="displayName"
             type="text"
+            autoComplete="nickname"
             required
-            className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-zinc-900 outline-none focus:border-zinc-400 dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
+            className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-base text-zinc-900 outline-none focus:border-zinc-400 sm:text-sm dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
           />
           {state.fieldErrorKeys?.displayName && (
             <p className="mt-1 text-sm text-rose-500">
@@ -55,8 +56,9 @@ export default function RegisterForm({
             id="birthDate"
             name="birthDate"
             type="date"
+            autoComplete="bday"
             required
-            className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-zinc-900 outline-none focus:border-zinc-400 dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
+            className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-base text-zinc-900 outline-none focus:border-zinc-400 sm:text-sm dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
           />
           {state.fieldErrorKeys?.birthDate && (
             <p className="mt-1 text-sm text-rose-500">
@@ -68,7 +70,7 @@ export default function RegisterForm({
         <button
           type="submit"
           disabled={isPending}
-          className="w-full rounded-full bg-foreground py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
+          className="inline-flex min-h-[44px] w-full items-center justify-center rounded-full bg-foreground py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
         >
           {isPending ? dict.submitting : dict.submit}
         </button>

--- a/src/app/[lang]/(user)/register/page.tsx
+++ b/src/app/[lang]/(user)/register/page.tsx
@@ -8,5 +8,9 @@ export default async function Register({ params }: { params: Promise<{ lang: str
   if (!isLocale(lang)) notFound();
   const dict = await getDictionary(lang);
 
-  return <RegisterForm lang={lang} dict={dict.register} />;
+  return (
+    <main className="flex flex-1 flex-col bg-zinc-50 px-4 py-8 sm:px-6 sm:py-12 dark:bg-black">
+      <RegisterForm lang={lang} dict={dict.register} />
+    </main>
+  );
 }

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/AddSetForm.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/AddSetForm.tsx
@@ -66,7 +66,7 @@ export default function AddSetForm({
         {exercises.length === 0 ? (
           <p className="text-sm text-zinc-500 dark:text-zinc-400">{dict.noExercises}</p>
         ) : (
-          <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
             {exercises.map((exercise) => {
               const id = exercise.exerciseId ?? '';
               const isSelected = id !== '' && selectedExerciseId === id;
@@ -86,7 +86,7 @@ export default function AddSetForm({
                     <ExerciseImage
                       code={exercise.code}
                       name={exercise.name ?? exercise.code}
-                      className="h-16 w-16"
+                      className="h-14 w-14 sm:h-16 sm:w-16"
                     />
                     <span className="text-xs font-medium text-zinc-700 dark:text-zinc-300">
                       {exercise.name ?? exercise.code ?? id}
@@ -116,11 +116,12 @@ export default function AddSetForm({
             id="rep"
             name="rep"
             type="number"
+            inputMode="numeric"
             min={1}
             step={1}
             required
             disabled={disabled}
-            className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-zinc-900 outline-none focus:border-zinc-400 disabled:opacity-50 dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
+            className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-base text-zinc-900 outline-none focus:border-zinc-400 disabled:opacity-50 sm:text-sm dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
           />
           {state.fieldErrorKeys?.rep && (
             <p className="mt-1 text-sm text-rose-500">{dict.errors[state.fieldErrorKeys.rep]}</p>
@@ -138,11 +139,12 @@ export default function AddSetForm({
             id="weight"
             name="weight"
             type="number"
+            inputMode="decimal"
             min={0}
             step="0.5"
             required
             disabled={disabled}
-            className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-zinc-900 outline-none focus:border-zinc-400 disabled:opacity-50 dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
+            className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-base text-zinc-900 outline-none focus:border-zinc-400 disabled:opacity-50 sm:text-sm dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
           />
           {state.fieldErrorKeys?.weight && (
             <p className="mt-1 text-sm text-rose-500">
@@ -167,7 +169,7 @@ export default function AddSetForm({
           required
           disabled={disabled}
           defaultValue={defaultTrainedAt}
-          className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-zinc-900 outline-none focus:border-zinc-400 disabled:opacity-50 dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
+          className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-base text-zinc-900 outline-none focus:border-zinc-400 disabled:opacity-50 sm:text-sm dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
         />
         {state.fieldErrorKeys?.trainedAt && (
           <p className="mt-1 text-sm text-rose-500">
@@ -179,7 +181,7 @@ export default function AddSetForm({
       <button
         type="submit"
         disabled={disabled || isPending || !selectedExerciseId}
-        className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] disabled:opacity-50 dark:hover:bg-[#ccc]"
+        className="inline-flex min-h-[44px] w-full items-center justify-center rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] disabled:opacity-50 sm:w-auto sm:self-start dark:hover:bg-[#ccc]"
       >
         {isPending ? dict.submitting : dict.submit}
       </button>

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
@@ -46,7 +46,7 @@ export default async function WorkoutDetailPage({
     return (
       <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
           {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
@@ -75,7 +75,7 @@ export default async function WorkoutDetailPage({
     return (
       <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
           <p className="text-rose-500">{t.loadFailed}</p>
           <Link
             href={`/${lang}/workouts`}
@@ -101,25 +101,25 @@ export default async function WorkoutDetailPage({
   const boundFinish = finishWorkout.bind(null, lang, workoutId);
 
   return (
-    <main className="flex flex-1 flex-col items-center bg-zinc-50 px-6 py-12 dark:bg-black">
+    <main className="flex flex-1 flex-col items-center bg-zinc-50 px-4 py-8 sm:px-6 sm:py-12 dark:bg-black">
       <div className="flex w-full max-w-3xl flex-col gap-6">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <Link
             href={`/${lang}/workouts`}
             className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
           >
             ← {dict.common.back}
           </Link>
-          <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+          <span className="shrink-0 rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
             {isFinished ? dict.workouts.status.finished : dict.workouts.status.inProgress}
           </span>
         </div>
 
-        <section className="rounded-2xl border border-black/[.08] bg-white p-5 dark:border-white/[.145] dark:bg-zinc-900">
-          <h1 className="mb-3 text-xl font-semibold text-zinc-900 dark:text-zinc-50">
+        <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
+          <h1 className="mb-3 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
             {t.detailsHeading}
           </h1>
-          <dl className="grid grid-cols-2 gap-y-2 text-sm">
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm sm:grid-cols-2">
             <dt className="text-zinc-500 dark:text-zinc-400">{t.startedLabel}</dt>
             <dd className="text-zinc-900 dark:text-zinc-50">
               <FormattedDateTime value={workout.startedAt} lang={lang} />
@@ -135,8 +135,8 @@ export default async function WorkoutDetailPage({
           <p className="text-sm text-rose-500">{t.finishFailed}</p>
         )}
 
-        <section className="rounded-2xl border border-black/[.08] bg-white p-5 dark:border-white/[.145] dark:bg-zinc-900">
-          <h2 className="mb-3 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+        <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
+          <h2 className="mb-3 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
             {t.setsHeading}
           </h2>
           {sets.length === 0 ? (
@@ -147,9 +147,16 @@ export default async function WorkoutDetailPage({
                 const exercise = exerciseFor(set, exerciseById);
                 const label = exerciseLabel(set, exerciseById, t.unknownExercise);
                 return (
-                  <li key={set.setId} className="flex items-center gap-3 py-2 text-sm">
-                    <ExerciseImage code={exercise?.code} name={label} className="h-12 w-12" />
-                    <span className="flex-1 text-zinc-900 dark:text-zinc-50">{label}</span>
+                  <li
+                    key={set.setId}
+                    className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2 text-sm"
+                  >
+                    <ExerciseImage
+                      code={exercise?.code}
+                      name={label}
+                      className="h-10 w-10 shrink-0 sm:h-12 sm:w-12"
+                    />
+                    <span className="min-w-0 flex-1 text-zinc-900 dark:text-zinc-50">{label}</span>
                     <span className="text-zinc-600 dark:text-zinc-400">
                       {translate(lang, t.setSummary, {
                         rep: set.rep ?? 0,
@@ -157,7 +164,7 @@ export default async function WorkoutDetailPage({
                         unit: dict.units.kg,
                       })}
                     </span>
-                    <span className="text-xs text-zinc-500 dark:text-zinc-500">
+                    <span className="w-full text-xs text-zinc-500 sm:w-auto sm:text-right dark:text-zinc-500">
                       <FormattedDateTime value={set.trainedAt} lang={lang} />
                     </span>
                   </li>
@@ -168,8 +175,8 @@ export default async function WorkoutDetailPage({
         </section>
 
         {!isFinished && (
-          <section className="rounded-2xl border border-black/[.08] bg-white p-5 dark:border-white/[.145] dark:bg-zinc-900">
-            <h2 className="mb-3 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+          <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
+            <h2 className="mb-3 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
               {t.addSetHeading}
             </h2>
             <AddSetForm
@@ -189,7 +196,7 @@ export default async function WorkoutDetailPage({
           <form action={boundFinish}>
             <button
               type="submit"
-              className="w-full rounded-full border border-black/[.08] bg-white py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-black/[.04] dark:border-white/[.145] dark:bg-zinc-900 dark:text-zinc-50 dark:hover:bg-[#1a1a1a]"
+              className="inline-flex min-h-[44px] w-full items-center justify-center rounded-full border border-black/[.08] bg-white py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-black/[.04] dark:border-white/[.145] dark:bg-zinc-900 dark:text-zinc-50 dark:hover:bg-[#1a1a1a]"
             >
               {t.finishButton}
             </button>

--- a/src/app/[lang]/(workout)/workouts/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/page.tsx
@@ -28,7 +28,7 @@ export default async function WorkoutsPage({
     return (
       <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
           {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
@@ -55,21 +55,21 @@ export default async function WorkoutsPage({
     workout.finishedAt ? t.status.finished : t.status.inProgress;
 
   return (
-    <main className="flex flex-1 flex-col items-center bg-zinc-50 px-6 py-12 dark:bg-black">
+    <main className="flex flex-1 flex-col items-center bg-zinc-50 px-4 py-8 sm:px-6 sm:py-12 dark:bg-black">
       <div className="flex w-full max-w-3xl flex-col gap-6">
-        <div className="flex items-center justify-between gap-3">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{t.title}</h1>
-          <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
+          <div className="flex flex-1 items-center justify-end gap-2 sm:flex-none">
             <Link
               href={`/${lang}/workouts/stats`}
-              className="rounded-full border border-black/[.08] px-5 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-black/[.04] dark:border-white/[.145] dark:text-zinc-50 dark:hover:bg-[#1a1a1a]"
+              className="inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full border border-black/[.08] px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-black/[.04] sm:flex-none sm:px-5 dark:border-white/[.145] dark:text-zinc-50 dark:hover:bg-[#1a1a1a]"
             >
               {t.stats}
             </Link>
-            <form action={boundStart}>
+            <form action={boundStart} className="flex-1 sm:flex-none">
               <button
                 type="submit"
-                className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-full bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] sm:w-auto sm:px-5 dark:hover:bg-[#ccc]"
               >
                 {t.start}
               </button>
@@ -94,9 +94,9 @@ export default async function WorkoutsPage({
               >
                 <Link
                   href={`/${lang}/workouts/${workout.workoutId}`}
-                  className="flex items-center justify-between gap-4"
+                  className="flex items-center justify-between gap-3"
                 >
-                  <div className="flex flex-col gap-1">
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
                     <span className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
                       {t.startedPrefix}
                       <FormattedDateTime value={workout.startedAt} lang={lang} />
@@ -106,7 +106,7 @@ export default async function WorkoutsPage({
                       <FormattedDateTime value={workout.finishedAt} lang={lang} />
                     </span>
                   </div>
-                  <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+                  <span className="shrink-0 rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
                     {statusLabel(workout)}
                   </span>
                 </Link>

--- a/src/app/[lang]/(workout)/workouts/stats/ActivityHeatmap.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/ActivityHeatmap.tsx
@@ -59,7 +59,7 @@ export default function ActivityHeatmap({ data, lang, dict }: Props) {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between text-sm">
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-sm">
         <p className="text-zinc-700 dark:text-zinc-300">
           {translate(lang, dict.summary, {
             total: totalWorkouts,

--- a/src/app/[lang]/(workout)/workouts/stats/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/page.tsx
@@ -29,7 +29,7 @@ export default async function WorkoutStatsPage({
     return (
       <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
           {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
@@ -50,9 +50,9 @@ export default async function WorkoutStatsPage({
 
   if (listResult.error) {
     return (
-      <main className="flex flex-1 flex-col items-center bg-zinc-50 px-6 py-12 dark:bg-black">
+      <main className="flex flex-1 flex-col items-center bg-zinc-50 px-4 py-8 sm:px-6 sm:py-12 dark:bg-black">
         <div className="flex w-full max-w-3xl flex-col gap-6">
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
           <p className="text-sm text-rose-500">{t.loadFailed}</p>
           <Link
             href={`/${lang}/workouts`}
@@ -92,31 +92,31 @@ export default async function WorkoutStatsPage({
   const detailFailures = detailResults.filter(({ result }) => !!result.error).length;
 
   return (
-    <main className="flex flex-1 flex-col items-center bg-zinc-50 px-6 py-12 dark:bg-black">
+    <main className="flex flex-1 flex-col items-center bg-zinc-50 px-4 py-8 sm:px-6 sm:py-12 dark:bg-black">
       <div className="flex w-full max-w-3xl flex-col gap-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <Link
             href={`/${lang}/workouts`}
             className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
           >
             ← {t.backToWorkouts}
           </Link>
-          <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
         </div>
 
         {workouts.length === 0 ? (
           <p className="text-zinc-600 dark:text-zinc-400">{t.empty}</p>
         ) : (
           <>
-            <section className="rounded-2xl border border-black/[.08] bg-white p-5 dark:border-white/[.145] dark:bg-zinc-900">
-              <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
+              <h2 className="mb-4 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
                 {t.activityHeading}
               </h2>
               <ActivityHeatmap data={dailyCounts} lang={lang} dict={t.heatmap} />
             </section>
 
-            <section className="rounded-2xl border border-black/[.08] bg-white p-5 dark:border-white/[.145] dark:bg-zinc-900">
-              <h2 className="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
+            <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
+              <h2 className="mb-4 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
                 {t.volumeHeading}
               </h2>
               {detailFailures > 0 && (

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -12,31 +12,33 @@ export default async function Home({ params }: { params: Promise<{ lang: string 
   const user = await getCurrentUser();
 
   return (
-    <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
+    <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-4 py-12 sm:px-6 sm:py-16 dark:bg-black">
       <div className="flex w-full max-w-2xl flex-col items-center gap-6 text-center">
-        <h1 className="text-4xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-50">
+        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900 sm:text-3xl dark:text-zinc-50">
           {dict.home.welcome}
         </h1>
         {user ? (
           <>
-            <p className="text-lg text-zinc-700 dark:text-zinc-300">
+            <p className="text-sm text-zinc-700 sm:text-base dark:text-zinc-300">
               {translate(lang, dict.home.signedInAs, { name: user.displayName ?? '' })}
             </p>
             <Link
               href={`/${lang}/workouts`}
-              className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-foreground px-6 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
             >
               {dict.home.ctaLoggedIn}
             </Link>
           </>
         ) : (
           <>
-            <p className="text-lg text-zinc-600 dark:text-zinc-400">{dict.home.ctaLoggedOut}</p>
+            <p className="text-sm text-zinc-600 sm:text-base dark:text-zinc-400">
+              {dict.home.ctaLoggedOut}
+            </p>
             {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
             {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a
               href="/api/auth/login"
-              className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-foreground px-6 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
             >
               {dict.common.login}
             </a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,15 +8,15 @@ export default async function Header({ lang, dict }: { lang: Locale; dict: Dicti
   const user = await getCurrentUser();
 
   return (
-    <header className="sticky top-0 z-20 flex w-full items-center justify-between border-b border-black/[.08] bg-white/80 px-6 py-3 backdrop-blur dark:border-white/[.145] dark:bg-black/80">
+    <header className="sticky top-0 z-20 flex w-full flex-wrap items-center justify-between gap-y-2 border-b border-black/[.08] bg-white/80 px-4 py-3 backdrop-blur sm:px-6 dark:border-white/[.145] dark:bg-black/80">
       <Link
         href={`/${lang}`}
-        className="text-xl font-bold tracking-tight text-zinc-900 hover:text-zinc-600 dark:text-zinc-50 dark:hover:text-zinc-300"
+        className="text-base font-bold tracking-tight text-zinc-900 hover:text-zinc-600 sm:text-lg dark:text-zinc-50 dark:hover:text-zinc-300"
       >
         {dict.common.appName}
       </Link>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-2 sm:gap-3">
         {user ? (
           <>
             <Link
@@ -25,14 +25,14 @@ export default async function Header({ lang, dict }: { lang: Locale; dict: Dicti
             >
               {dict.header.workouts}
             </Link>
-            <span className="hidden text-sm text-zinc-600 sm:inline dark:text-zinc-400">
+            <span className="hidden max-w-[10rem] truncate text-sm text-zinc-600 sm:inline dark:text-zinc-400">
               {user.displayName}
             </span>
             {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
             {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a
               href="/api/auth/logout"
-              className="rounded-full border border-solid border-black/[.08] px-5 py-2 text-sm font-medium transition-colors hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a]"
+              className="inline-flex min-h-[40px] items-center justify-center rounded-full border border-solid border-black/[.08] px-4 py-2 text-sm font-medium transition-colors hover:bg-black/[.04] sm:px-5 dark:border-white/[.145] dark:hover:bg-[#1a1a1a]"
             >
               {dict.common.logout}
             </a>
@@ -42,7 +42,7 @@ export default async function Header({ lang, dict }: { lang: Locale; dict: Dicti
           /* eslint-disable-next-line @next/next/no-html-link-for-pages */
           <a
             href="/api/auth/login"
-            className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+            className="inline-flex min-h-[40px] items-center justify-center rounded-full bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] sm:px-5 dark:hover:bg-[#ccc]"
           >
             {dict.common.login}
           </a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,7 +25,7 @@ export default async function Header({ lang, dict }: { lang: Locale; dict: Dicti
             >
               {dict.header.workouts}
             </Link>
-            <span className="hidden max-w-[10rem] truncate text-sm text-zinc-600 sm:inline dark:text-zinc-400">
+            <span className="hidden max-w-[10rem] truncate text-sm text-zinc-600 sm:inline-block dark:text-zinc-400">
               {user.displayName}
             </span>
             {/* OAuth route handler: must be <a> to trigger a full browser navigation */}


### PR DESCRIPTION
Closes #16.

## Summary
- Made every page render without horizontal scrolling on common viewport widths (320 / 375 / 768 / 1024 / 1440).
- Adopted a mobile-first approach with Tailwind responsive utilities (`sm:`, `md:`), bumping padding, layout (`flex-wrap` for header rows), and column counts at wider breakpoints.
- Enforced 40–44px tap targets on primary buttons and the auth controls in the header.
- Bumped numeric / date inputs to `text-base` on mobile (downshifting to `text-sm` at `sm:`) to prevent iOS focus zoom, and added `inputMode` / `autoComplete` hints.
- Toned heading typography down one Tailwind step on mobile so it matches a more typical modern app feel (e.g. page `h1` is `text-xl sm:text-2xl`, section `h2` is `text-base sm:text-lg`).
- Charts (activity heatmap, volume chart) keep their existing `overflow-x-auto` container so they pan inside the card without forcing the whole page to scroll horizontally.

## Commits
Split per screen / component for easier review:
- `feat: make header responsive for mobile screens`
- `feat: make home page responsive`
- `feat: make register page responsive`
- `feat: make workouts list page responsive`
- `feat: make workout detail page and AddSetForm responsive`
- `feat: make stats page and activity heatmap responsive`

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] In Chrome DevTools device mode, verify there is no horizontal page scroll at 320 / 375 / 768 / 1024 / 1440 widths on each route (`/`, `/register`, `/workouts`, `/workouts/[id]`, `/workouts/stats`) in both `/en` and `/ja`.
- [ ] Header items stay tappable at 320px and the display name truncates rather than overflowing.
- [ ] Workouts list header keeps Stats + Start workout buttons usable on mobile.
- [ ] AddSetForm exercise grid renders 2 columns on mobile, 3 on `sm`, 4 on `md`; numeric/date inputs do not trigger iOS zoom on focus.
- [ ] Stats page heatmap and volume chart scroll horizontally inside their cards but the page itself does not.
- [ ] Dark mode still looks correct on each route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)