### PR TITLE
feat: track personal records and show PR badges

### DIFF
--- a/src/app/[lang]/(user)/register/actions.ts
+++ b/src/app/[lang]/(user)/register/actions.ts
@@ -24,8 +24,6 @@ function parseBirthDate(raw: string): { year: number; month: number; day: number
   const month = Number(match[2]);
   const day = Number(match[3]);
 
-  // Reject rollovers such as 2024-02-31 → Mar 2 by checking the UTC fields
-  // round-trip to the same y/m/d.
   const date = new Date(Date.UTC(year, month - 1, day));
   if (
     date.getUTCFullYear() !== year ||

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/AddSetForm.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/AddSetForm.tsx
@@ -32,12 +32,14 @@ export default function AddSetForm({
   disabled,
   dict,
   kgUnit,
+  prLabels,
 }: {
   workoutId: string;
   exercises: Exercise[];
   disabled: boolean;
   dict: Dictionary['addSet'];
   kgUnit: string;
+  prLabels: { weight: string; volume: string };
 }) {
   const [selectedExerciseId, setSelectedExerciseId] = useState('');
 
@@ -147,9 +149,7 @@ export default function AddSetForm({
             className="w-full rounded-lg border border-black/[.08] bg-white px-3 py-2 text-base text-zinc-900 outline-none focus:border-zinc-400 disabled:opacity-50 sm:text-sm dark:border-white/[.145] dark:bg-zinc-950 dark:text-zinc-50"
           />
           {state.fieldErrorKeys?.weight && (
-            <p className="mt-1 text-sm text-rose-500">
-              {dict.errors[state.fieldErrorKeys.weight]}
-            </p>
+            <p className="mt-1 text-sm text-rose-500">{dict.errors[state.fieldErrorKeys.weight]}</p>
           )}
         </div>
       </div>
@@ -187,6 +187,26 @@ export default function AddSetForm({
       </button>
 
       {state.errorKey && <p className="text-sm text-rose-500">{dict.errors[state.errorKey]}</p>}
+
+      {state.pr && (state.pr.weight || state.pr.volume) && (
+        <p
+          role="status"
+          aria-live="polite"
+          className="flex flex-wrap items-center gap-1.5 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200"
+        >
+          <span>{dict.prBanner}</span>
+          {state.pr.weight && (
+            <span role="img" aria-label={prLabels.weight} title={prLabels.weight}>
+              👑
+            </span>
+          )}
+          {state.pr.volume && (
+            <span role="img" aria-label={prLabels.volume} title={prLabels.volume}>
+              💪
+            </span>
+          )}
+        </p>
+      )}
     </form>
   );
 }

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/AddSetForm.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/AddSetForm.tsx
@@ -42,9 +42,10 @@ export default function AddSetForm({
   prLabels: { weight: string; volume: string };
 }) {
   const [selectedExerciseId, setSelectedExerciseId] = useState('');
+  const [showPr, setShowPr] = useState(false);
 
   const boundAction = createSet.bind(null, workoutId);
-  const wrappedAction = (prev: CreateSetFormState, formData: FormData) => {
+  const wrappedAction = async (prev: CreateSetFormState, formData: FormData) => {
     const raw = String(formData.get('trainedAt') ?? '');
     if (raw) {
       const local = new Date(raw);
@@ -52,14 +53,16 @@ export default function AddSetForm({
         formData.set('trainedAt', local.toISOString());
       }
     }
-    return boundAction(prev, formData);
+    const result = await boundAction(prev, formData);
+    setShowPr(!!result.pr && (result.pr.weight || result.pr.volume));
+    return result;
   };
   const [state, formAction, isPending] = useActionState(wrappedAction, initialState);
 
   const defaultTrainedAt = useSyncExternalStore(noopSubscribe, getClientNow, emptyDefault);
 
   return (
-    <form action={formAction} className="flex flex-col gap-4">
+    <form action={formAction} onChange={() => setShowPr(false)} className="flex flex-col gap-4">
       <fieldset disabled={disabled}>
         <legend className="mb-2 block text-sm font-medium text-zinc-700 dark:text-zinc-300">
           {dict.exercise}
@@ -76,7 +79,10 @@ export default function AddSetForm({
                 <li key={id || exercise.code}>
                   <button
                     type="button"
-                    onClick={() => setSelectedExerciseId(id)}
+                    onClick={() => {
+                      setSelectedExerciseId(id);
+                      setShowPr(false);
+                    }}
                     disabled={!id}
                     aria-pressed={isSelected}
                     className={`flex w-full flex-col items-center gap-1 rounded-xl border p-2 text-center transition-colors disabled:opacity-50 ${
@@ -188,7 +194,7 @@ export default function AddSetForm({
 
       {state.errorKey && <p className="text-sm text-rose-500">{dict.errors[state.errorKey]}</p>}
 
-      {state.pr && (state.pr.weight || state.pr.volume) && (
+      {showPr && state.pr && (state.pr.weight || state.pr.volume) && (
         <p
           role="status"
           aria-live="polite"

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/actions.ts
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/actions.ts
@@ -1,11 +1,13 @@
 'use server';
 
 import { client as setClient } from '@/app/api/set/client';
+import { fetchAllSets } from '@/app/api/set/list';
 import { client as workoutClient } from '@/app/api/workout/client';
 import { localePrefix } from '@/i18n/format';
 import { getAccessToken } from '@/lib/session';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
+import { computePrFlags, type PrFlags } from './records';
 
 export type CreateSetErrorKey = 'notSignedIn' | 'createFailed';
 export type CreateSetFieldErrorKey =
@@ -22,6 +24,7 @@ export type CreateSetFormState = {
     weight?: CreateSetFieldErrorKey;
     trainedAt?: CreateSetFieldErrorKey;
   };
+  pr?: PrFlags;
 };
 
 const TIMEZONE_SUFFIX = /(Z|[+-]\d{2}:?\d{2})$/i;
@@ -69,7 +72,7 @@ export async function createSet(
     return { errorKey: 'notSignedIn' };
   }
 
-  const { error } = await setClient.POST('/v1/sets', {
+  const { error, data } = await setClient.POST('/v1/sets', {
     headers: { Authorization: `Bearer ${accessToken}` },
     body: {
       workoutId,
@@ -84,8 +87,17 @@ export async function createSet(
     return { errorKey: 'createFailed' };
   }
 
+  const newSetId = data?.setId;
+  let pr: PrFlags | undefined;
+  if (newSetId) {
+    const allSets = await fetchAllSets(accessToken);
+    if (!allSets.error) {
+      pr = computePrFlags(allSets.sets).get(newSetId);
+    }
+  }
+
   revalidatePath(`/workouts/${workoutId}`);
-  return {};
+  return pr && (pr.weight || pr.volume) ? { pr } : {};
 }
 
 export async function finishWorkout(lang: string, workoutId: string) {

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
@@ -48,7 +48,6 @@ export default async function WorkoutDetailPage({
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
           <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
-          {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
           <a
             href="/api/auth/login"

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
@@ -3,6 +3,7 @@ import { fetchAllSets } from '@/app/api/set/list';
 import { client as workoutClient } from '@/app/api/workout/client';
 import ExerciseImage from '@/components/ExerciseImage';
 import FormattedDateTime from '@/components/FormattedDateTime';
+import LoginLink from '@/components/LoginLink';
 import { isLocale } from '@/i18n/config';
 import { translate } from '@/i18n/format';
 import { getDictionary } from '@/i18n/getDictionary';
@@ -52,13 +53,9 @@ export default async function WorkoutDetailPage({
             {t.title}
           </h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
-          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-          <a
-            href="/api/auth/login"
-            className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
-          >
+          <LoginLink className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]">
             {dict.common.login}
-          </a>
+          </LoginLink>
         </div>
       </main>
     );

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
@@ -1,4 +1,5 @@
 import { client as exerciseClient } from '@/app/api/exercise/client';
+import { fetchAllSets } from '@/app/api/set/list';
 import { client as workoutClient } from '@/app/api/workout/client';
 import ExerciseImage from '@/components/ExerciseImage';
 import FormattedDateTime from '@/components/FormattedDateTime';
@@ -12,6 +13,7 @@ import type { components as exerciseSchema } from '../../../../../../gen/exercis
 import type { components as workoutSchema } from '../../../../../../gen/workout/v1/workout.schema';
 import AddSetForm from './AddSetForm';
 import { finishWorkout } from './actions';
+import { computePrFlags } from './records';
 
 type Workout = workoutSchema['schemas']['v1Workout'];
 type Set = workoutSchema['schemas']['v1Set'];
@@ -46,7 +48,9 @@ export default async function WorkoutDetailPage({
     return (
       <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
-          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+            {t.title}
+          </h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
           <a
@@ -60,7 +64,7 @@ export default async function WorkoutDetailPage({
     );
   }
 
-  const [workoutResult, exercisesResult] = await Promise.all([
+  const [workoutResult, exercisesResult, allSetsResult] = await Promise.all([
     workoutClient.GET('/v1/workouts/{workoutId}', {
       params: { path: { workoutId } },
       headers: { Authorization: `Bearer ${accessToken}` },
@@ -68,13 +72,16 @@ export default async function WorkoutDetailPage({
     exerciseClient.GET('/v1/exercises', {
       headers: { Authorization: `Bearer ${accessToken}` },
     }),
+    fetchAllSets(accessToken),
   ]);
 
   if (workoutResult.error || !workoutResult.data?.workout) {
     return (
       <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
-          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+            {t.title}
+          </h1>
           <p className="text-rose-500">{t.loadFailed}</p>
           <Link
             href={`/${lang}/workouts`}
@@ -95,6 +102,7 @@ export default async function WorkoutDetailPage({
       .filter((exercise): exercise is Exercise & { exerciseId: string } => !!exercise.exerciseId)
       .map((exercise) => [exercise.exerciseId, exercise]),
   );
+  const prFlagsById = computePrFlags(allSetsResult.sets);
   const isFinished = !!workout.finishedAt;
 
   const boundFinish = finishWorkout.bind(null, lang, workoutId);
@@ -145,6 +153,7 @@ export default async function WorkoutDetailPage({
               {sets.map((set) => {
                 const exercise = exerciseFor(set, exerciseById);
                 const label = exerciseLabel(set, exerciseById, t.unknownExercise);
+                const prFlags = set.setId ? prFlagsById.get(set.setId) : undefined;
                 return (
                   <li
                     key={set.setId}
@@ -163,6 +172,30 @@ export default async function WorkoutDetailPage({
                         unit: dict.units.kg,
                       })}
                     </span>
+                    {prFlags && (
+                      <span className="flex shrink-0 items-center gap-0.5 leading-none">
+                        {prFlags.weight && (
+                          <span
+                            role="img"
+                            aria-label={t.prBadgeWeight}
+                            title={t.prBadgeWeight}
+                            className="text-base"
+                          >
+                            👑
+                          </span>
+                        )}
+                        {prFlags.volume && (
+                          <span
+                            role="img"
+                            aria-label={t.prBadgeVolume}
+                            title={t.prBadgeVolume}
+                            className="text-base"
+                          >
+                            💪
+                          </span>
+                        )}
+                      </span>
+                    )}
                     <span className="w-full text-xs text-zinc-500 sm:w-auto sm:text-right dark:text-zinc-500">
                       <FormattedDateTime value={set.trainedAt} lang={lang} />
                     </span>
@@ -184,6 +217,7 @@ export default async function WorkoutDetailPage({
               disabled={isFinished}
               dict={dict.addSet}
               kgUnit={dict.units.kg}
+              prLabels={{ weight: t.prBadgeWeight, volume: t.prBadgeVolume }}
             />
             {exercisesResult.error && (
               <p className="mt-2 text-sm text-rose-500">{t.loadExercisesFailed}</p>

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/records.ts
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/records.ts
@@ -1,0 +1,54 @@
+export type RecordableSet = {
+  setId?: string;
+  exerciseId?: string;
+  rep?: number;
+  weight?: number;
+  trainedAt?: string;
+  createdAt?: string;
+};
+
+export type PrFlags = {
+  weight: boolean;
+  volume: boolean;
+};
+
+function volumeOf(set: RecordableSet): number {
+  return (set.rep ?? 0) * (set.weight ?? 0);
+}
+
+function chronological(a: RecordableSet, b: RecordableSet): number {
+  const t = (a.trainedAt ?? '').localeCompare(b.trainedAt ?? '');
+  if (t !== 0) return t;
+  const c = (a.createdAt ?? '').localeCompare(b.createdAt ?? '');
+  if (c !== 0) return c;
+  return (a.setId ?? '').localeCompare(b.setId ?? '');
+}
+
+export function computePrFlags(sets: RecordableSet[]): Map<string, PrFlags> {
+  const byExercise = new Map<string, RecordableSet[]>();
+  for (const set of sets) {
+    if (!set.setId || !set.exerciseId || !set.trainedAt) continue;
+    const bucket = byExercise.get(set.exerciseId);
+    if (bucket) bucket.push(set);
+    else byExercise.set(set.exerciseId, [set]);
+  }
+
+  const flags = new Map<string, PrFlags>();
+  for (const bucket of byExercise.values()) {
+    bucket.sort(chronological);
+    let maxWeight = -Infinity;
+    let maxVolume = -Infinity;
+    for (const set of bucket) {
+      const weight = set.weight ?? 0;
+      const volume = volumeOf(set);
+      const weightPr = weight > maxWeight;
+      const volumePr = volume > maxVolume;
+      if (weightPr) maxWeight = weight;
+      if (volumePr) maxVolume = volume;
+      if (weightPr || volumePr) {
+        flags.set(set.setId!, { weight: weightPr, volume: volumePr });
+      }
+    }
+  }
+  return flags;
+}

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/records.ts
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/records.ts
@@ -16,12 +16,18 @@ function volumeOf(set: RecordableSet): number {
   return (set.rep ?? 0) * (set.weight ?? 0);
 }
 
+function compare(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
 function chronological(a: RecordableSet, b: RecordableSet): number {
-  const t = (a.trainedAt ?? '').localeCompare(b.trainedAt ?? '');
+  const t = compare(a.trainedAt ?? '', b.trainedAt ?? '');
   if (t !== 0) return t;
-  const c = (a.createdAt ?? '').localeCompare(b.createdAt ?? '');
+  const c = compare(a.createdAt ?? '', b.createdAt ?? '');
   if (c !== 0) return c;
-  return (a.setId ?? '').localeCompare(b.setId ?? '');
+  return compare(a.setId ?? '', b.setId ?? '');
 }
 
 export function computePrFlags(sets: RecordableSet[]): Map<string, PrFlags> {

--- a/src/app/[lang]/(workout)/workouts/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/page.tsx
@@ -30,7 +30,6 @@ export default async function WorkoutsPage({
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
           <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
-          {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
           <a
             href="/api/auth/login"

--- a/src/app/[lang]/(workout)/workouts/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/page.tsx
@@ -1,5 +1,6 @@
 import { client as workoutClient } from '@/app/api/workout/client';
 import FormattedDateTime from '@/components/FormattedDateTime';
+import LoginLink from '@/components/LoginLink';
 import { isLocale } from '@/i18n/config';
 import { getDictionary } from '@/i18n/getDictionary';
 import { getAccessToken } from '@/lib/session';
@@ -28,15 +29,13 @@ export default async function WorkoutsPage({
     return (
       <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
-          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+            {t.title}
+          </h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
-          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-          <a
-            href="/api/auth/login"
-            className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
-          >
+          <LoginLink className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]">
             {dict.common.login}
-          </a>
+          </LoginLink>
         </div>
       </main>
     );
@@ -57,7 +56,9 @@ export default async function WorkoutsPage({
     <main className="flex flex-1 flex-col items-center bg-zinc-50 px-4 py-8 sm:px-6 sm:py-12 dark:bg-black">
       <div className="flex w-full max-w-3xl flex-col gap-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+            {t.title}
+          </h1>
           <div className="flex flex-1 items-center justify-end gap-2 sm:flex-none">
             <Link
               href={`/${lang}/workouts/stats`}
@@ -76,9 +77,7 @@ export default async function WorkoutsPage({
           </div>
         </div>
 
-        {errorParam === 'start_failed' && (
-          <p className="text-sm text-rose-500">{t.startFailed}</p>
-        )}
+        {errorParam === 'start_failed' && <p className="text-sm text-rose-500">{t.startFailed}</p>}
 
         {error ? (
           <p className="text-sm text-rose-500">{t.loadFailed}</p>

--- a/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
+++ b/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
@@ -29,7 +29,6 @@ export function buildDailyCounts(workouts: Workout[], weeks: number): DailyCount
 
   const start = new Date(today);
   start.setDate(start.getDate() - (totalDays - 1));
-  // Align the start to the previous Sunday so the grid lays out cleanly.
   start.setDate(start.getDate() - start.getDay());
 
   const counts = new Map<string, number>();

--- a/src/app/[lang]/(workout)/workouts/stats/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/page.tsx
@@ -1,4 +1,5 @@
 import { client as workoutClient } from '@/app/api/workout/client';
+import LoginLink from '@/components/LoginLink';
 import { isLocale } from '@/i18n/config';
 import { getDictionary } from '@/i18n/getDictionary';
 import { getAccessToken } from '@/lib/session';
@@ -14,11 +15,7 @@ type Set = workoutSchema['schemas']['v1Set'];
 
 const HEATMAP_WEEKS = 12;
 
-export default async function WorkoutStatsPage({
-  params,
-}: {
-  params: Promise<{ lang: string }>;
-}) {
+export default async function WorkoutStatsPage({ params }: { params: Promise<{ lang: string }> }) {
   const { lang } = await params;
   if (!isLocale(lang)) notFound();
   const dict = await getDictionary(lang);
@@ -29,15 +26,13 @@ export default async function WorkoutStatsPage({
     return (
       <main className="flex flex-1 flex-col items-center justify-center bg-zinc-50 px-6 py-16 dark:bg-black">
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
-          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+            {t.title}
+          </h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
-          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-          <a
-            href="/api/auth/login"
-            className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
-          >
+          <LoginLink className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]">
             {dict.common.login}
-          </a>
+          </LoginLink>
         </div>
       </main>
     );
@@ -51,7 +46,9 @@ export default async function WorkoutStatsPage({
     return (
       <main className="flex flex-1 flex-col items-center bg-zinc-50 px-4 py-8 sm:px-6 sm:py-12 dark:bg-black">
         <div className="flex w-full max-w-3xl flex-col gap-6">
-          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+            {t.title}
+          </h1>
           <p className="text-sm text-rose-500">{t.loadFailed}</p>
           <Link
             href={`/${lang}/workouts`}
@@ -100,7 +97,9 @@ export default async function WorkoutStatsPage({
           >
             ← {t.backToWorkouts}
           </Link>
-          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
+          <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">
+            {t.title}
+          </h1>
         </div>
 
         {workouts.length === 0 ? (

--- a/src/app/[lang]/(workout)/workouts/stats/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/page.tsx
@@ -31,7 +31,6 @@ export default async function WorkoutStatsPage({
         <div className="flex w-full max-w-2xl flex-col items-center gap-4 text-center">
           <h1 className="text-xl font-semibold text-zinc-900 sm:text-2xl dark:text-zinc-50">{t.title}</h1>
           <p className="text-zinc-600 dark:text-zinc-400">{t.loginPrompt}</p>
-          {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
           <a
             href="/api/auth/login"

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -1,3 +1,4 @@
+import LoginLink from '@/components/LoginLink';
 import { isLocale } from '@/i18n/config';
 import { translate } from '@/i18n/format';
 import { getDictionary } from '@/i18n/getDictionary';
@@ -34,13 +35,9 @@ export default async function Home({ params }: { params: Promise<{ lang: string 
             <p className="text-sm text-zinc-600 sm:text-base dark:text-zinc-400">
               {dict.home.ctaLoggedOut}
             </p>
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a
-              href="/api/auth/login"
-              className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-foreground px-6 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
-            >
+            <LoginLink className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-foreground px-6 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]">
               {dict.common.login}
-            </a>
+            </LoginLink>
           </>
         )}
       </div>

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -34,7 +34,6 @@ export default async function Home({ params }: { params: Promise<{ lang: string 
             <p className="text-sm text-zinc-600 sm:text-base dark:text-zinc-400">
               {dict.home.ctaLoggedOut}
             </p>
-            {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
             {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a
               href="/api/auth/login"

--- a/src/app/api/set/list.ts
+++ b/src/app/api/set/list.ts
@@ -1,0 +1,22 @@
+import type { components } from '../../../../gen/set/v1/set.schema';
+import { client as setClient } from './client';
+
+type Set = components['schemas']['v1Set'];
+
+const PAGE_SIZE = 500;
+
+export async function fetchAllSets(accessToken: string): Promise<{ sets: Set[]; error?: unknown }> {
+  const sets: Set[] = [];
+  let pageToken: string | undefined;
+
+  while (true) {
+    const { data, error } = await setClient.GET('/v1/sets', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      params: { query: { pageSize: PAGE_SIZE, pageToken } },
+    });
+    if (error) return { sets, error };
+    if (data?.sets) sets.push(...data.sets);
+    if (!data?.nextPageToken) return { sets };
+    pageToken = data.nextPageToken;
+  }
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,6 @@
 import LanguageSwitcher from '@/components/LanguageSwitcher';
+import LoginLink from '@/components/LoginLink';
+import LogoutLink from '@/components/LogoutLink';
 import type { Locale } from '@/i18n/config';
 import type { Dictionary } from '@/i18n/getDictionary';
 import { getCurrentUser } from '@/lib/session';
@@ -28,22 +30,14 @@ export default async function Header({ lang, dict }: { lang: Locale; dict: Dicti
             <span className="hidden max-w-[10rem] truncate text-sm text-zinc-600 sm:inline-block dark:text-zinc-400">
               {user.displayName}
             </span>
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a
-              href="/api/auth/logout"
-              className="inline-flex min-h-[40px] items-center justify-center rounded-full border border-solid border-black/[.08] px-4 py-2 text-sm font-medium transition-colors hover:bg-black/[.04] sm:px-5 dark:border-white/[.145] dark:hover:bg-[#1a1a1a]"
-            >
+            <LogoutLink className="inline-flex min-h-[40px] items-center justify-center rounded-full border border-solid border-black/[.08] px-4 py-2 text-sm font-medium transition-colors hover:bg-black/[.04] sm:px-5 dark:border-white/[.145] dark:hover:bg-[#1a1a1a]">
               {dict.common.logout}
-            </a>
+            </LogoutLink>
           </>
         ) : (
-          /* eslint-disable-next-line @next/next/no-html-link-for-pages */
-          <a
-            href="/api/auth/login"
-            className="inline-flex min-h-[40px] items-center justify-center rounded-full bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] sm:px-5 dark:hover:bg-[#ccc]"
-          >
+          <LoginLink className="inline-flex min-h-[40px] items-center justify-center rounded-full bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] sm:px-5 dark:hover:bg-[#ccc]">
             {dict.common.login}
-          </a>
+          </LoginLink>
         )}
         <LanguageSwitcher lang={lang} label={dict.language.label} names={dict.language.names} />
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,7 +28,6 @@ export default async function Header({ lang, dict }: { lang: Locale; dict: Dicti
             <span className="hidden max-w-[10rem] truncate text-sm text-zinc-600 sm:inline-block dark:text-zinc-400">
               {user.displayName}
             </span>
-            {/* OAuth route handler: must be <a> to trigger a full browser navigation */}
             {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a
               href="/api/auth/logout"
@@ -38,7 +37,6 @@ export default async function Header({ lang, dict }: { lang: Locale; dict: Dicti
             </a>
           </>
         ) : (
-          /* OAuth route handler: must be <a> to trigger a full browser navigation */
           /* eslint-disable-next-line @next/next/no-html-link-for-pages */
           <a
             href="/api/auth/login"

--- a/src/components/LoginLink.tsx
+++ b/src/components/LoginLink.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export default function LoginLink({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
+    <a href="/api/auth/login" className={className}>
+      {children}
+    </a>
+  );
+}

--- a/src/components/LogoutLink.tsx
+++ b/src/components/LogoutLink.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export default function LogoutLink({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    // eslint-disable-next-line @next/next/no-html-link-for-pages
+    <a href="/api/auth/logout" className={className}>
+      {children}
+    </a>
+  );
+}

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -59,7 +59,9 @@
     "addSetHeading": "Add set",
     "finishButton": "Finish workout",
     "finishFailed": "Failed to finish workout. Please try again.",
-    "loadExercisesFailed": "Failed to load exercises."
+    "loadExercisesFailed": "Failed to load exercises.",
+    "prBadgeWeight": "Personal best (weight)",
+    "prBadgeVolume": "Personal best (volume)"
   },
   "addSet": {
     "exercise": "Exercise",
@@ -76,7 +78,8 @@
       "trainedAtInvalid": "A valid trained-at time is required.",
       "notSignedIn": "You must be signed in to record a set.",
       "createFailed": "Failed to record set. Please try again."
-    }
+    },
+    "prBanner": "🎉 New personal best!"
   },
   "stats": {
     "title": "Workout stats",

--- a/src/i18n/dictionaries/ja.json
+++ b/src/i18n/dictionaries/ja.json
@@ -59,7 +59,9 @@
     "addSetHeading": "セットを追加",
     "finishButton": "ワークアウトを終了",
     "finishFailed": "ワークアウトの終了に失敗しました。もう一度お試しください。",
-    "loadExercisesFailed": "種目の読み込みに失敗しました。"
+    "loadExercisesFailed": "種目の読み込みに失敗しました。",
+    "prBadgeWeight": "自己ベスト（重量）",
+    "prBadgeVolume": "自己ベスト（ボリューム）"
   },
   "addSet": {
     "exercise": "種目",
@@ -76,7 +78,8 @@
       "trainedAtInvalid": "有効な実施日時を入力してください。",
       "notSignedIn": "セットを記録するにはサインインが必要です。",
       "createFailed": "セットの記録に失敗しました。もう一度お試しください。"
-    }
+    },
+    "prBanner": "🎉 自己ベスト更新！"
   },
   "stats": {
     "title": "ワークアウト統計",


### PR DESCRIPTION
Closes #24.

## Summary

Track per-exercise personal records (max weight and max volume = `rep × weight`) across the user's entire set history, and crown the sets that established each new record in the workout detail list. After a freshly added set sets a new PR, the form surfaces a celebration banner.

## PR semantics

A set is a PR for an exercise when, in chronological order (`trainedAt → createdAt → setId`), its `weight` or `rep × weight` strictly exceeds every earlier same-exercise set's. The first set ever recorded for an exercise establishes the initial record. Ties after a record do not re-crown.

Two icons distinguish the dimensions:

| Icon | Dimension |
|------|-----------|
| 👑    | Max weight |
| 💪    | Max volume |

Each icon has a localized tooltip (`Personal best (weight)` / `自己ベスト（重量）`, etc.) so a user can disambiguate on hover, while the badge area itself stays compact.

## Implementation

- `src/app/[lang]/(workout)/workouts/[workoutId]/records.ts` — pure `computePrFlags(sets)` returning a `Map<setId, { weight, volume }>` of the sets that established a PR. Kept dependency-free for easy reasoning.
- `src/app/api/set/list.ts` — `fetchAllSets(accessToken)` paginates `/v1/sets` and returns the user's full history.
- Workout detail page parallelizes the all-sets fetch alongside the workout and exercise fetches, then renders the badges per row.
- The create-set server action awaits the POST, refetches all sets, and reuses `computePrFlags` to determine whether the newly created set holds a PR. It's serialized (not parallel) so the snapshot definitely includes the new set — this avoids a tie-breaking race when the `datetime-local` input (minute precision) produces two sets with the same `trainedAt`.

## Also in this PR

Two small cleanups bundled in for branch hygiene:

- **`refactor`**: extract `LoginLink` / `LogoutLink` from the five `<a href="/api/auth/...">` occurrences. The OAuth route handlers need a real browser navigation (cookie + server redirect), so `<a>` was correct, but the per-callsite `eslint-disable-next-line @next/next/no-html-link-for-pages` is noisy. The two new components own the URL, the anchor, and a single eslint-disable each.
- **`chore`**: remove explanatory prose comments throughout `src/` (keeping functional `eslint-disable` directives), to match the project's "code explains itself" preference.

## Commits

```
61f3505 refactor: extract LoginLink and LogoutLink components (#24)
386d23a feat: track personal records and show PR badges (#24)
f44775a chore: remove explanatory inline comments (#24)
```

Each commit's tree was verified to independently pass `tsc --noEmit` and `eslint`.

## Manual verification

- New exercise → first set: 👑💪 (initial records).
- Same exercise, heavier weight: 👑 only.
- Same exercise, higher volume with lower weight: 💪 only.
- Same exercise, exact repeat: no badge, no banner.
- Two sets entered within the same minute: chronological ordering still attributes correctly thanks to the `createdAt → setId` tie-breakers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)