### PR TITLE
feat: add muscle-group balance body map

### DIFF
--- a/src/app/[lang]/(workout)/workouts/stats/BodyMap.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/BodyMap.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import type { Locale } from '@/i18n/config';
+import { translate } from '@/i18n/format';
+import type { Dictionary } from '@/i18n/getDictionary';
+import { useState } from 'react';
+import {
+  MUSCLE_BALANCE_PERIODS,
+  MUSCLE_CODES,
+  type MuscleBalanceByPeriod,
+  type MuscleBalancePeriod,
+  type MuscleCode,
+  type MuscleVolume,
+} from './aggregate';
+import {
+  type BodyView,
+  MAX_SCALE,
+  MIN_SCALE,
+  VIEWBOX_HEIGHT,
+  VIEWBOX_WIDTH,
+  musclesForView,
+} from './bodyShapes';
+
+type Dict = Dictionary['stats']['muscleBalance'];
+
+type Props = {
+  byPeriod: MuscleBalanceByPeriod;
+  lang: Locale;
+  dict: Dict;
+};
+
+function formatVolume(value: number): string {
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1)}k`;
+  }
+  return String(Math.round(value));
+}
+
+function BaseFigure({ view }: { view: BodyView }) {
+  return (
+    <g className="fill-zinc-200 dark:fill-zinc-800">
+      <circle cx={60} cy={20} r={12} />
+      {view === 'front' && (
+        <g className="fill-zinc-400 dark:fill-zinc-500">
+          <circle cx={56} cy={18} r={1.6} />
+          <circle cx={64} cy={18} r={1.6} />
+        </g>
+      )}
+      <rect x={55} y={29} width={10} height={9} rx={3} />
+      <path d="M40 42 Q60 36 80 42 L74 110 Q60 116 46 110 Z" />
+      <rect x={20} y={46} width={14} height={68} rx={7} />
+      <rect x={86} y={46} width={14} height={68} rx={7} />
+      <rect x={44} y={108} width={14} height={100} rx={7} />
+      <rect x={62} y={108} width={14} height={100} rx={7} />
+    </g>
+  );
+}
+
+function BodyFigure({
+  view,
+  label,
+  intensityByCode,
+  volumeByCode,
+  dict,
+  lang,
+}: {
+  view: BodyView;
+  label: string;
+  intensityByCode: Map<MuscleCode, number>;
+  volumeByCode: Map<MuscleCode, number>;
+  dict: Dict;
+  lang: Locale;
+}) {
+  const muscles = musclesForView(view);
+
+  return (
+    <figure className="flex flex-col items-center gap-2">
+      <svg
+        viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+        className="h-auto w-full max-w-[180px]"
+        role="img"
+        aria-label={label}
+      >
+        <BaseFigure view={view} />
+        {MUSCLE_CODES.map((code) => {
+          const shapes = muscles[code];
+          if (shapes.length === 0) return null;
+          const intensity = intensityByCode.get(code) ?? 0;
+          const volume = volumeByCode.get(code) ?? 0;
+          const trained = volume > 0;
+          const scale = MIN_SCALE + intensity * (MAX_SCALE - MIN_SCALE);
+          const muscleName = dict.muscles[code];
+          const tooltip = trained
+            ? translate(lang, dict.tooltip, {
+                muscle: muscleName,
+                value: formatVolume(volume),
+                unit: dict.unit,
+              })
+            : translate(lang, dict.untrainedTooltip, { muscle: muscleName });
+          return (
+            <g
+              key={code}
+              className={
+                trained
+                  ? 'fill-emerald-500 dark:fill-emerald-500'
+                  : 'fill-zinc-300 stroke-zinc-400 dark:fill-zinc-700 dark:stroke-zinc-600'
+              }
+              style={trained ? { opacity: 0.45 + intensity * 0.55 } : { opacity: 0.6 }}
+            >
+              <title>{tooltip}</title>
+              {shapes.map((shape, index) => (
+                <ellipse
+                  key={index}
+                  cx={shape.cx}
+                  cy={shape.cy}
+                  rx={shape.rx}
+                  ry={shape.ry}
+                  strokeDasharray={trained ? undefined : '2 2'}
+                  strokeWidth={trained ? 0 : 1}
+                  transform={`translate(${shape.cx} ${shape.cy}) scale(${scale}) translate(${-shape.cx} ${-shape.cy})`}
+                />
+              ))}
+            </g>
+          );
+        })}
+      </svg>
+      <figcaption className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+        {label}
+      </figcaption>
+    </figure>
+  );
+}
+
+function BalanceView({ data, lang, dict }: { data: MuscleVolume[]; lang: Locale; dict: Dict }) {
+  const max = data.reduce((acc, d) => Math.max(acc, d.volume), 0);
+
+  if (max === 0) {
+    return <p className="text-sm text-zinc-600 dark:text-zinc-400">{dict.empty}</p>;
+  }
+
+  const intensityByCode = new Map<MuscleCode, number>(data.map((d) => [d.code, d.volume / max]));
+  const volumeByCode = new Map<MuscleCode, number>(data.map((d) => [d.code, d.volume]));
+  const untrained = MUSCLE_CODES.filter((code) => (volumeByCode.get(code) ?? 0) === 0);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-4" role="img" aria-label={dict.ariaLabel}>
+        <BodyFigure
+          view="front"
+          label={dict.frontLabel}
+          intensityByCode={intensityByCode}
+          volumeByCode={volumeByCode}
+          dict={dict}
+          lang={lang}
+        />
+        <BodyFigure
+          view="back"
+          label={dict.backLabel}
+          intensityByCode={intensityByCode}
+          volumeByCode={volumeByCode}
+          dict={dict}
+          lang={lang}
+        />
+      </div>
+      <ul className="flex flex-col divide-y divide-black/[.06] text-sm dark:divide-white/[.08]">
+        {MUSCLE_CODES.map((code) => {
+          const volume = volumeByCode.get(code) ?? 0;
+          return (
+            <li key={code} className="flex items-center justify-between gap-3 py-2">
+              <span className="text-zinc-700 dark:text-zinc-300">{dict.muscles[code]}</span>
+              <span className="text-zinc-900 tabular-nums dark:text-zinc-50">
+                {formatVolume(volume)} <span className="text-xs text-zinc-500">{dict.unit}</span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+        {untrained.length === 0
+          ? dict.allTrained
+          : translate(lang, dict.untrainedHint, {
+              muscles: untrained
+                .map((code) => dict.muscles[code])
+                .join(lang === 'ja' ? '、' : ', '),
+            })}
+      </p>
+    </div>
+  );
+}
+
+export default function BodyMap({ byPeriod, lang, dict }: Props) {
+  const [period, setPeriod] = useState<MuscleBalancePeriod>('all');
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div
+        role="tablist"
+        aria-label={dict.ariaLabel}
+        className="flex gap-1 self-start rounded-full bg-zinc-100 p-1 dark:bg-zinc-800"
+      >
+        {MUSCLE_BALANCE_PERIODS.map((value) => {
+          const selected = value === period;
+          return (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              onClick={() => setPeriod(value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                selected
+                  ? 'bg-white text-zinc-900 shadow-sm dark:bg-zinc-950 dark:text-zinc-50'
+                  : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+              }`}
+            >
+              {dict.periods[value]}
+            </button>
+          );
+        })}
+      </div>
+      <BalanceView data={byPeriod[period]} lang={lang} dict={dict} />
+    </div>
+  );
+}

--- a/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
+++ b/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
@@ -1,7 +1,28 @@
+import type { components as exerciseSchema } from '../../../../../../gen/exercise/v1/exercise.schema';
 import type { components as workoutSchema } from '../../../../../../gen/workout/v1/workout.schema';
 
 type Workout = workoutSchema['schemas']['v1Workout'];
 type Set = workoutSchema['schemas']['v1Set'];
+type Exercise = exerciseSchema['schemas']['v1Exercise'];
+
+export const MUSCLE_CODES = ['chest', 'back', 'legs', 'shoulders', 'arms', 'core'] as const;
+export type MuscleCode = (typeof MUSCLE_CODES)[number];
+
+export type MuscleVolume = {
+  code: MuscleCode;
+  volume: number;
+};
+
+export const MUSCLE_BALANCE_PERIODS = ['week', 'month', 'all'] as const;
+export type MuscleBalancePeriod = (typeof MUSCLE_BALANCE_PERIODS)[number];
+
+const PERIOD_DAYS: Record<MuscleBalancePeriod, number | null> = {
+  week: 7,
+  month: 30,
+  all: null,
+};
+
+export type MuscleBalanceByPeriod = Record<MuscleBalancePeriod, MuscleVolume[]>;
 
 export type DailyCount = {
   date: string;
@@ -60,6 +81,53 @@ export function computeWorkoutVolume(sets: Set[]): number {
     volume += rep * weight;
   }
   return volume;
+}
+
+function isMuscleCode(code: string): code is MuscleCode {
+  return (MUSCLE_CODES as readonly string[]).includes(code);
+}
+
+export function buildMuscleBalance(
+  entries: { workout: Workout; sets: Set[] }[],
+  exerciseById: Map<string, Exercise>,
+  since: Date | null = null,
+): MuscleVolume[] {
+  const totals = new Map<MuscleCode, number>(MUSCLE_CODES.map((code) => [code, 0]));
+  const sinceMs = since?.getTime() ?? null;
+
+  for (const { sets } of entries) {
+    for (const set of sets) {
+      if (!set.exerciseId) continue;
+      if (sinceMs !== null) {
+        if (!set.trainedAt) continue;
+        if (new Date(set.trainedAt).getTime() < sinceMs) continue;
+      }
+      const exercise = exerciseById.get(set.exerciseId);
+      if (!exercise?.muscles) continue;
+      const volume = (set.rep ?? 0) * (set.weight ?? 0);
+      if (volume === 0) continue;
+      for (const muscle of exercise.muscles) {
+        if (!muscle.code || !isMuscleCode(muscle.code)) continue;
+        totals.set(muscle.code, (totals.get(muscle.code) ?? 0) + volume);
+      }
+    }
+  }
+
+  return MUSCLE_CODES.map((code) => ({ code, volume: totals.get(code) ?? 0 }));
+}
+
+export function buildMuscleBalanceByPeriod(
+  entries: { workout: Workout; sets: Set[] }[],
+  exerciseById: Map<string, Exercise>,
+  now: Date,
+): MuscleBalanceByPeriod {
+  const result = {} as MuscleBalanceByPeriod;
+  for (const period of MUSCLE_BALANCE_PERIODS) {
+    const days = PERIOD_DAYS[period];
+    const since = days === null ? null : new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    result[period] = buildMuscleBalance(entries, exerciseById, since);
+  }
+  return result;
 }
 
 export function buildWorkoutVolumes(entries: { workout: Workout; sets: Set[] }[]): WorkoutVolume[] {

--- a/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
+++ b/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
@@ -100,7 +100,7 @@ export function buildMuscleBalance(
       if (!set.exerciseId) continue;
       if (sinceMs !== null) {
         if (!set.trainedAt) continue;
-        if (new Date(set.trainedAt).getTime() < sinceMs) continue;
+        if (Date.parse(set.trainedAt) < sinceMs) continue;
       }
       const exercise = exerciseById.get(set.exerciseId);
       if (!exercise?.muscles) continue;

--- a/src/app/[lang]/(workout)/workouts/stats/bodyShapes.ts
+++ b/src/app/[lang]/(workout)/workouts/stats/bodyShapes.ts
@@ -1,0 +1,59 @@
+import type { MuscleCode } from './aggregate';
+
+export type Muscle = { cx: number; cy: number; rx: number; ry: number };
+
+export const VIEWBOX_WIDTH = 120;
+export const VIEWBOX_HEIGHT = 220;
+
+export const MIN_SCALE = 0.7;
+export const MAX_SCALE = 1.45;
+
+export type BodyView = 'front' | 'back';
+
+export const FRONT_MUSCLES: Record<MuscleCode, Muscle[]> = {
+  shoulders: [
+    { cx: 34, cy: 50, rx: 11, ry: 10 },
+    { cx: 86, cy: 50, rx: 11, ry: 10 },
+  ],
+  chest: [
+    { cx: 49, cy: 64, rx: 13, ry: 11 },
+    { cx: 71, cy: 64, rx: 13, ry: 11 },
+  ],
+  arms: [
+    { cx: 27, cy: 84, rx: 8, ry: 17 },
+    { cx: 93, cy: 84, rx: 8, ry: 17 },
+  ],
+  core: [{ cx: 60, cy: 94, rx: 14, ry: 19 }],
+  legs: [
+    { cx: 50, cy: 148, rx: 11, ry: 33 },
+    { cx: 70, cy: 148, rx: 11, ry: 33 },
+  ],
+  back: [],
+};
+
+export const BACK_MUSCLES: Record<MuscleCode, Muscle[]> = {
+  shoulders: [
+    { cx: 34, cy: 50, rx: 11, ry: 10 },
+    { cx: 86, cy: 50, rx: 11, ry: 10 },
+  ],
+  back: [
+    { cx: 49, cy: 67, rx: 13, ry: 17 },
+    { cx: 71, cy: 67, rx: 13, ry: 17 },
+  ],
+  arms: [
+    { cx: 27, cy: 84, rx: 8, ry: 17 },
+    { cx: 93, cy: 84, rx: 8, ry: 17 },
+  ],
+  legs: [
+    { cx: 50, cy: 120, rx: 12, ry: 14 },
+    { cx: 70, cy: 120, rx: 12, ry: 14 },
+    { cx: 50, cy: 158, rx: 11, ry: 28 },
+    { cx: 70, cy: 158, rx: 11, ry: 28 },
+  ],
+  chest: [],
+  core: [],
+};
+
+export function musclesForView(view: BodyView): Record<MuscleCode, Muscle[]> {
+  return view === 'front' ? FRONT_MUSCLES : BACK_MUSCLES;
+}

--- a/src/app/[lang]/(workout)/workouts/stats/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/page.tsx
@@ -105,6 +105,7 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
   const muscleBalance = buildMuscleBalanceByPeriod(detailEntries, exerciseById, new Date());
   const lifetimeVolume = workoutVolumes.reduce((sum, w) => sum + w.volume, 0);
   const detailFailures = detailResults.filter(({ result }) => !!result.error).length;
+  const exercisesFailed = !!exercisesResult.error;
 
   return (
     <main className="flex flex-1 flex-col items-center bg-zinc-50 px-4 py-8 sm:px-6 sm:py-12 dark:bg-black">
@@ -148,6 +149,9 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
               <h2 className="mb-4 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
                 {t.muscleBalanceHeading}
               </h2>
+              {exercisesFailed && (
+                <p className="mb-3 text-xs text-rose-500">{t.muscleBalanceLoadFailed}</p>
+              )}
               <BodyMap byPeriod={muscleBalance} lang={lang} dict={t.muscleBalance} />
             </section>
           </>

--- a/src/app/[lang]/(workout)/workouts/stats/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/page.tsx
@@ -1,3 +1,4 @@
+import { client as exerciseClient } from '@/app/api/exercise/client';
 import { client as workoutClient } from '@/app/api/workout/client';
 import LoginLink from '@/components/LoginLink';
 import { isLocale } from '@/i18n/config';
@@ -5,14 +6,17 @@ import { getDictionary } from '@/i18n/getDictionary';
 import { getAccessToken } from '@/lib/session';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type { components as exerciseSchema } from '../../../../../../gen/exercise/v1/exercise.schema';
 import type { components as workoutSchema } from '../../../../../../gen/workout/v1/workout.schema';
 import ActivityHeatmap from './ActivityHeatmap';
+import BodyMap from './BodyMap';
 import LifetimeVolumeCard from './LifetimeVolumeCard';
 import VolumeChart from './VolumeChart';
-import { buildDailyCounts, buildWorkoutVolumes } from './aggregate';
+import { buildDailyCounts, buildMuscleBalanceByPeriod, buildWorkoutVolumes } from './aggregate';
 
 type Workout = workoutSchema['schemas']['v1Workout'];
 type Set = workoutSchema['schemas']['v1Set'];
+type Exercise = exerciseSchema['schemas']['v1Exercise'];
 
 const HEATMAP_WEEKS = 12;
 
@@ -39,9 +43,14 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
     );
   }
 
-  const listResult = await workoutClient.GET('/v1/workouts', {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
+  const [listResult, exercisesResult] = await Promise.all([
+    workoutClient.GET('/v1/workouts', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }),
+    exerciseClient.GET('/v1/exercises', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    }),
+  ]);
 
   if (listResult.error) {
     return (
@@ -84,8 +93,16 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
     }),
   );
 
+  const exercises: Exercise[] = exercisesResult.data?.exercises ?? [];
+  const exerciseById = new Map<string, Exercise>(
+    exercises
+      .filter((exercise): exercise is Exercise & { exerciseId: string } => !!exercise.exerciseId)
+      .map((exercise) => [exercise.exerciseId, exercise]),
+  );
+
   const dailyCounts = buildDailyCounts(workouts, HEATMAP_WEEKS);
   const workoutVolumes = buildWorkoutVolumes(detailEntries);
+  const muscleBalance = buildMuscleBalanceByPeriod(detailEntries, exerciseById, new Date());
   const lifetimeVolume = workoutVolumes.reduce((sum, w) => sum + w.volume, 0);
   const detailFailures = detailResults.filter(({ result }) => !!result.error).length;
 
@@ -125,6 +142,13 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
                 <p className="mb-3 text-xs text-rose-500">{t.detailPartialFailure}</p>
               )}
               <VolumeChart data={workoutVolumes} lang={lang} dict={t.volume} />
+            </section>
+
+            <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
+              <h2 className="mb-4 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
+                {t.muscleBalanceHeading}
+              </h2>
+              <BodyMap byPeriod={muscleBalance} lang={lang} dict={t.muscleBalance} />
             </section>
           </>
         )}

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -90,6 +90,7 @@
     "activityHeading": "Activity",
     "volumeHeading": "Volume per workout",
     "muscleBalanceHeading": "Muscle group balance",
+    "muscleBalanceLoadFailed": "Could not load exercise data, so muscle balance may be incomplete.",
     "detailPartialFailure": "Some workouts could not be loaded; volume may be incomplete.",
     "lifetimeVolume": {
       "heading": "Total volume lifted",

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -89,6 +89,7 @@
     "empty": "No workouts to visualize yet. Record your first workout to see your stats.",
     "activityHeading": "Activity",
     "volumeHeading": "Volume per workout",
+    "muscleBalanceHeading": "Muscle group balance",
     "detailPartialFailure": "Some workouts could not be loaded; volume may be incomplete.",
     "lifetimeVolume": {
       "heading": "Total volume lifted",
@@ -120,6 +121,30 @@
       "ariaLabel": "Volume per workout",
       "unit": "rep × kg",
       "tooltip": "{date} — {value} ({unit})"
+    },
+    "muscleBalance": {
+      "empty": "No sets recorded yet — once you log sets, your muscle balance will show up here.",
+      "ariaLabel": "Muscle group training balance shown on front and back body maps",
+      "frontLabel": "Front",
+      "backLabel": "Back",
+      "unit": "rep × kg",
+      "tooltip": "{muscle} — {value} ({unit})",
+      "untrainedTooltip": "{muscle} — not trained yet",
+      "untrainedHint": "Under-trained: {muscles}",
+      "allTrained": "Every muscle group has been trained — nicely balanced!",
+      "periods": {
+        "week": "Last 7 days",
+        "month": "Last 30 days",
+        "all": "All time"
+      },
+      "muscles": {
+        "chest": "Chest",
+        "back": "Back",
+        "legs": "Legs",
+        "shoulders": "Shoulders",
+        "arms": "Arms",
+        "core": "Core"
+      }
     }
   },
   "language": {

--- a/src/i18n/dictionaries/ja.json
+++ b/src/i18n/dictionaries/ja.json
@@ -90,6 +90,7 @@
     "activityHeading": "アクティビティ",
     "volumeHeading": "ワークアウト別ボリューム",
     "muscleBalanceHeading": "筋群バランス",
+    "muscleBalanceLoadFailed": "種目データを読み込めなかったため、筋群バランスが不完全な可能性があります。",
     "detailPartialFailure": "一部のワークアウトを読み込めませんでした。ボリュームが不完全な可能性があります。",
     "lifetimeVolume": {
       "heading": "累積総挙上ボリューム",

--- a/src/i18n/dictionaries/ja.json
+++ b/src/i18n/dictionaries/ja.json
@@ -89,6 +89,7 @@
     "empty": "まだ可視化できるワークアウトがありません。最初のワークアウトを記録すると統計が表示されます。",
     "activityHeading": "アクティビティ",
     "volumeHeading": "ワークアウト別ボリューム",
+    "muscleBalanceHeading": "筋群バランス",
     "detailPartialFailure": "一部のワークアウトを読み込めませんでした。ボリュームが不完全な可能性があります。",
     "lifetimeVolume": {
       "heading": "累積総挙上ボリューム",
@@ -120,6 +121,30 @@
       "ariaLabel": "ワークアウト別ボリューム",
       "unit": "回 × kg",
       "tooltip": "{date} — {value} ({unit})"
+    },
+    "muscleBalance": {
+      "empty": "まだセットが記録されていません。セットを記録すると筋群バランスが表示されます。",
+      "ariaLabel": "前面・背面の人体図で表す筋群トレーニングバランス",
+      "frontLabel": "前面",
+      "backLabel": "背面",
+      "unit": "回 × kg",
+      "tooltip": "{muscle} — {value}（{unit}）",
+      "untrainedTooltip": "{muscle} — まだ鍛えていません",
+      "untrainedHint": "鍛えられていない部位: {muscles}",
+      "allTrained": "すべての筋群が鍛えられています。バランス良好です！",
+      "periods": {
+        "week": "直近7日",
+        "month": "直近30日",
+        "all": "全期間"
+      },
+      "muscles": {
+        "chest": "胸",
+        "back": "背中",
+        "legs": "脚",
+        "shoulders": "肩",
+        "arms": "腕",
+        "core": "体幹"
+      }
     }
   },
   "language": {


### PR DESCRIPTION
## Summary

Closes #26.

Adds a **muscle-group balance** visualization to the stats page. Each set's exercise is mapped to its muscle groups, volume (`rep × weight`) is aggregated per group, and the result is rendered on front/back body maps where each muscle is *fleshed out* — it grows and brightens with relative training volume, while under-trained groups stay thin and greyed out.

## What's included

- **Aggregation** (`aggregate.ts`): `buildMuscleBalance` maps `set.exerciseId → exercise.muscles[]` into per-group volume over an optional time window; `buildMuscleBalanceByPeriod` produces last-7-days / last-30-days / all-time datasets.
- **Body map** (`BodyMap.tsx`, `bodyShapes.ts`): SVG front/back figures. Muscle size scales with volume relative to the most-trained group (so it shows *balance*, not absolute totals — it never all maxes out over time). The front figure has a face to make orientation obvious. Period tabs let the user switch windows. Under-trained groups are listed and called out.
- **Stats page** (`page.tsx`): fetches `/v1/exercises` in parallel, builds the per-group map, and renders the card.
- **i18n**: muscle-group names, period labels, and copy localized for `ja` and `en`.

## Notes

- Size is **relative** to the most-trained group, so continued training does not make everything max out — a chronically neglected group stays visibly small.
- Responsive and dark-mode aware, following the existing chart conventions.

## Acceptance criteria

- [x] Sets are correctly mapped to muscle groups via exercise metadata.
- [x] Trained vs. under-trained groups are clearly visualized.
- [x] Visualization is responsive and dark-mode aware.
- [x] Copy and muscle-group names are localized for ja and en.

## Verification

- `tsc`, `eslint`, and `next build` pass.
- Verified end-to-end in the browser with seeded data: all-time shows all six groups with a clear size hierarchy; last-7-days highlights recently neglected groups (back / legs / core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)