### PR TITLE
feat: add per-exercise progression line chart

### DIFF
--- a/src/app/[lang]/(workout)/workouts/stats/ExerciseProgressChart.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/ExerciseProgressChart.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import FormattedDateTime from '@/components/FormattedDateTime';
+import type { Locale } from '@/i18n/config';
+import { translate } from '@/i18n/format';
+import type { Dictionary } from '@/i18n/getDictionary';
+import Link from 'next/link';
+import { useState } from 'react';
+import {
+  type ExerciseProgression,
+  PROGRESSION_METRICS,
+  type ProgressionMetric,
+  type ProgressionPoint,
+} from './aggregate';
+
+type Dict = Dictionary['stats']['progression'];
+
+type Props = {
+  series: ExerciseProgression[];
+  lang: Locale;
+  dict: Dict;
+};
+
+const CHART_HEIGHT = 180;
+const PADDING_LEFT = 40;
+const PADDING_TOP = 12;
+const PADDING_BOTTOM = 28;
+const PADDING_INNER = 20;
+const POINT_GAP = 56;
+const POINT_RADIUS = 3.5;
+
+function metricValue(point: ProgressionPoint, metric: ProgressionMetric): number {
+  return metric === 'maxWeight' ? point.maxWeight : point.volume;
+}
+
+function formatValue(value: number, metric: ProgressionMetric): string {
+  if (metric === 'volume') {
+    if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+    return String(Math.round(value));
+  }
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+export default function ExerciseProgressChart({ series, lang, dict }: Props) {
+  const [selectedExerciseId, setSelectedExerciseId] = useState(series[0]?.exerciseId ?? '');
+  const [metric, setMetric] = useState<ProgressionMetric>('maxWeight');
+
+  if (series.length === 0) {
+    return <p className="text-sm text-zinc-600 dark:text-zinc-400">{dict.empty}</p>;
+  }
+
+  const selected = series.find((s) => s.exerciseId === selectedExerciseId) ?? series[0];
+  const points = selected.points;
+  const unit = dict.units[metric];
+
+  const max = points.reduce((acc, p) => Math.max(acc, metricValue(p, metric)), 0);
+  const safeMax = max === 0 ? 1 : max;
+  const chartWidth = PADDING_LEFT + PADDING_INNER * 2 + Math.max(points.length - 1, 0) * POINT_GAP;
+  const totalHeight = PADDING_TOP + CHART_HEIGHT + PADDING_BOTTOM;
+  const gridLines = [0, 0.25, 0.5, 0.75, 1];
+
+  const x = (index: number) => PADDING_LEFT + PADDING_INNER + index * POINT_GAP;
+  const y = (value: number) => PADDING_TOP + CHART_HEIGHT * (1 - value / safeMax);
+
+  const dateFormatter = new Intl.DateTimeFormat(lang, { month: 'numeric', day: 'numeric' });
+  const polylinePoints = points.map((p, i) => `${x(i)},${y(metricValue(p, metric))}`).join(' ');
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400">
+          <span className="sr-only">{dict.selectLabel}</span>
+          <select
+            value={selected.exerciseId}
+            onChange={(e) => setSelectedExerciseId(e.target.value)}
+            aria-label={dict.selectLabel}
+            className="rounded-lg border border-black/[.08] bg-white px-3 py-1.5 text-sm text-zinc-900 dark:border-white/[.145] dark:bg-zinc-800 dark:text-zinc-50"
+          >
+            {series.map((s) => (
+              <option key={s.exerciseId} value={s.exerciseId}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div
+          role="tablist"
+          aria-label={dict.metricLabel}
+          className="flex gap-1 rounded-full bg-zinc-100 p-1 dark:bg-zinc-800"
+        >
+          {PROGRESSION_METRICS.map((value) => {
+            const active = value === metric;
+            return (
+              <button
+                key={value}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setMetric(value)}
+                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+                  active
+                    ? 'bg-white text-zinc-900 shadow-sm dark:bg-zinc-950 dark:text-zinc-50'
+                    : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50'
+                }`}
+              >
+                {dict.metrics[value]}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {points.length < 2 && (
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">{dict.sparse}</p>
+      )}
+
+      <div className="overflow-x-auto">
+        <svg
+          width={chartWidth}
+          height={totalHeight}
+          viewBox={`0 0 ${chartWidth} ${totalHeight}`}
+          role="img"
+          aria-label={translate(lang, dict.ariaLabel, {
+            exercise: selected.name,
+            metric: dict.metrics[metric],
+          })}
+        >
+          {gridLines.map((ratio) => {
+            const gy = PADDING_TOP + CHART_HEIGHT * (1 - ratio);
+            return (
+              <g key={ratio}>
+                <line
+                  x1={PADDING_LEFT}
+                  x2={chartWidth}
+                  y1={gy}
+                  y2={gy}
+                  className="stroke-zinc-200 dark:stroke-zinc-800"
+                  strokeDasharray={ratio === 0 ? undefined : '2 3'}
+                />
+                <text
+                  x={PADDING_LEFT - 6}
+                  y={gy + 3}
+                  textAnchor="end"
+                  className="fill-zinc-500 text-[10px] dark:fill-zinc-400"
+                >
+                  {formatValue(safeMax * ratio, metric)}
+                </text>
+              </g>
+            );
+          })}
+
+          {points.length >= 2 && (
+            <polyline
+              points={polylinePoints}
+              fill="none"
+              className="stroke-emerald-500 dark:stroke-emerald-500"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          )}
+
+          {points.map((point, index) => {
+            const value = metricValue(point, metric);
+            return (
+              <g key={point.workoutId}>
+                <circle
+                  cx={x(index)}
+                  cy={y(value)}
+                  r={POINT_RADIUS}
+                  className="fill-emerald-500 dark:fill-emerald-500"
+                >
+                  <title>
+                    {translate(lang, dict.tooltip, {
+                      date: dateFormatter.format(new Date(point.date)),
+                      value: formatValue(value, metric),
+                      unit,
+                    })}
+                  </title>
+                </circle>
+                <text
+                  x={x(index)}
+                  y={PADDING_TOP + CHART_HEIGHT + 16}
+                  textAnchor="middle"
+                  className="fill-zinc-500 text-[10px] dark:fill-zinc-400"
+                >
+                  {dateFormatter.format(new Date(point.date))}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <ul className="flex flex-col divide-y divide-black/[.06] text-sm dark:divide-white/[.08]">
+        {points
+          .slice()
+          .reverse()
+          .map((point) => (
+            <li key={point.workoutId} className="flex items-center justify-between gap-3 py-2">
+              <Link
+                href={`/${lang}/workouts/${point.workoutId}`}
+                className="text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-50"
+              >
+                <FormattedDateTime value={point.date} lang={lang} />
+              </Link>
+              <span className="text-zinc-900 tabular-nums dark:text-zinc-50">
+                {formatValue(metricValue(point, metric), metric)}{' '}
+                <span className="text-xs text-zinc-500">{unit}</span>
+              </span>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
+++ b/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
@@ -189,7 +189,7 @@ export function buildExerciseProgressions(
   for (const [exerciseId, points] of byExercise) {
     const exercise = exerciseById.get(exerciseId);
     if (!exercise?.name) continue;
-    points.sort((a, b) => a.date.localeCompare(b.date));
+    points.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
     result.push({ exerciseId, name: exercise.name, points });
   }
 

--- a/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
+++ b/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
@@ -35,6 +35,22 @@ export type WorkoutVolume = {
   volume: number;
 };
 
+export const PROGRESSION_METRICS = ['maxWeight', 'volume'] as const;
+export type ProgressionMetric = (typeof PROGRESSION_METRICS)[number];
+
+export type ProgressionPoint = {
+  workoutId: string;
+  date: string;
+  maxWeight: number;
+  volume: number;
+};
+
+export type ExerciseProgression = {
+  exerciseId: string;
+  name: string;
+  points: ProgressionPoint[];
+};
+
 function toLocalDateKey(iso: string): string {
   const date = new Date(iso);
   const year = date.getFullYear();
@@ -139,4 +155,43 @@ export function buildWorkoutVolumes(entries: { workout: Workout; sets: Set[] }[]
       volume: computeWorkoutVolume(sets),
     }))
     .sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+}
+
+export function buildExerciseProgressions(
+  entries: { workout: Workout; sets: Set[] }[],
+  exerciseById: Map<string, Exercise>,
+): ExerciseProgression[] {
+  const byExercise = new Map<string, ProgressionPoint[]>();
+
+  for (const { workout, sets } of entries) {
+    if (!workout.workoutId || !workout.startedAt) continue;
+
+    const perExercise = new Map<string, { maxWeight: number; volume: number }>();
+    for (const set of sets) {
+      if (!set.exerciseId) continue;
+      const weight = set.weight ?? 0;
+      const rep = set.rep ?? 0;
+      const current = perExercise.get(set.exerciseId) ?? { maxWeight: 0, volume: 0 };
+      current.maxWeight = Math.max(current.maxWeight, weight);
+      current.volume += rep * weight;
+      perExercise.set(set.exerciseId, current);
+    }
+
+    for (const [exerciseId, { maxWeight, volume }] of perExercise) {
+      if (maxWeight === 0 && volume === 0) continue;
+      const points = byExercise.get(exerciseId) ?? [];
+      points.push({ workoutId: workout.workoutId, date: workout.startedAt, maxWeight, volume });
+      byExercise.set(exerciseId, points);
+    }
+  }
+
+  const result: ExerciseProgression[] = [];
+  for (const [exerciseId, points] of byExercise) {
+    const exercise = exerciseById.get(exerciseId);
+    if (!exercise?.name) continue;
+    points.sort((a, b) => a.date.localeCompare(b.date));
+    result.push({ exerciseId, name: exercise.name, points });
+  }
+
+  return result.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/app/[lang]/(workout)/workouts/stats/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/page.tsx
@@ -10,9 +10,15 @@ import type { components as exerciseSchema } from '../../../../../../gen/exercis
 import type { components as workoutSchema } from '../../../../../../gen/workout/v1/workout.schema';
 import ActivityHeatmap from './ActivityHeatmap';
 import BodyMap from './BodyMap';
+import ExerciseProgressChart from './ExerciseProgressChart';
 import LifetimeVolumeCard from './LifetimeVolumeCard';
 import VolumeChart from './VolumeChart';
-import { buildDailyCounts, buildMuscleBalanceByPeriod, buildWorkoutVolumes } from './aggregate';
+import {
+  buildDailyCounts,
+  buildExerciseProgressions,
+  buildMuscleBalanceByPeriod,
+  buildWorkoutVolumes,
+} from './aggregate';
 
 type Workout = workoutSchema['schemas']['v1Workout'];
 type Set = workoutSchema['schemas']['v1Set'];
@@ -102,6 +108,7 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
 
   const dailyCounts = buildDailyCounts(workouts, HEATMAP_WEEKS);
   const workoutVolumes = buildWorkoutVolumes(detailEntries);
+  const exerciseProgressions = buildExerciseProgressions(detailEntries, exerciseById);
   const muscleBalance = buildMuscleBalanceByPeriod(detailEntries, exerciseById, new Date());
   const lifetimeVolume = workoutVolumes.reduce((sum, w) => sum + w.volume, 0);
   const detailFailures = detailResults.filter(({ result }) => !!result.error).length;
@@ -143,6 +150,20 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
                 <p className="mb-3 text-xs text-rose-500">{t.detailPartialFailure}</p>
               )}
               <VolumeChart data={workoutVolumes} lang={lang} dict={t.volume} />
+            </section>
+
+            <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
+              <h2 className="mb-4 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
+                {t.progressionHeading}
+              </h2>
+              {detailFailures > 0 && (
+                <p className="mb-3 text-xs text-rose-500">{t.detailPartialFailure}</p>
+              )}
+              <ExerciseProgressChart
+                series={exerciseProgressions}
+                lang={lang}
+                dict={t.progression}
+              />
             </section>
 
             <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -90,6 +90,7 @@
     "activityHeading": "Activity",
     "volumeHeading": "Volume per workout",
     "muscleBalanceHeading": "Muscle group balance",
+    "progressionHeading": "Per-exercise progression",
     "muscleBalanceLoadFailed": "Could not load exercise data, so muscle balance may be incomplete.",
     "detailPartialFailure": "Some workouts could not be loaded; volume may be incomplete.",
     "lifetimeVolume": {
@@ -122,6 +123,22 @@
       "ariaLabel": "Volume per workout",
       "unit": "rep × kg",
       "tooltip": "{date} — {value} ({unit})"
+    },
+    "progression": {
+      "empty": "No exercises to chart yet — once you log sets, per-exercise progression will show up here.",
+      "sparse": "Only one session recorded for this exercise. Log more sessions to see a trend.",
+      "selectLabel": "Select exercise",
+      "metricLabel": "Select metric",
+      "ariaLabel": "{metric} progression for {exercise}",
+      "tooltip": "{date} — {value} ({unit})",
+      "metrics": {
+        "maxWeight": "Max weight",
+        "volume": "Volume"
+      },
+      "units": {
+        "maxWeight": "kg",
+        "volume": "rep × kg"
+      }
     },
     "muscleBalance": {
       "empty": "No sets recorded yet — once you log sets, your muscle balance will show up here.",

--- a/src/i18n/dictionaries/ja.json
+++ b/src/i18n/dictionaries/ja.json
@@ -90,6 +90,7 @@
     "activityHeading": "アクティビティ",
     "volumeHeading": "ワークアウト別ボリューム",
     "muscleBalanceHeading": "筋群バランス",
+    "progressionHeading": "種目別の推移",
     "muscleBalanceLoadFailed": "種目データを読み込めなかったため、筋群バランスが不完全な可能性があります。",
     "detailPartialFailure": "一部のワークアウトを読み込めませんでした。ボリュームが不完全な可能性があります。",
     "lifetimeVolume": {
@@ -122,6 +123,22 @@
       "ariaLabel": "ワークアウト別ボリューム",
       "unit": "回 × kg",
       "tooltip": "{date} — {value} ({unit})"
+    },
+    "progression": {
+      "empty": "まだ推移を表示できる種目がありません。セットを記録すると種目別の推移が表示されます。",
+      "sparse": "この種目の記録が1回分しかありません。複数回記録すると推移が表示されます。",
+      "selectLabel": "種目を選択",
+      "metricLabel": "指標を選択",
+      "ariaLabel": "{exercise}の{metric}の推移",
+      "tooltip": "{date} — {value} ({unit})",
+      "metrics": {
+        "maxWeight": "最大重量",
+        "volume": "ボリューム"
+      },
+      "units": {
+        "maxWeight": "kg",
+        "volume": "回 × kg"
+      }
     },
     "muscleBalance": {
       "empty": "まだセットが記録されていません。セットを記録すると筋群バランスが表示されます。",


### PR DESCRIPTION
## Summary

Adds a **per-exercise progression line chart** to the stats page so users can see weight/volume trending over time for a selected exercise. Closes #27.

- New aggregate `buildExerciseProgressions` computes max weight and volume per session for each exercise, as date-sorted point lists.
- New `ExerciseProgressChart` client component: pick an exercise (`<select>`) and a metric (max weight / volume) and view its trend as an SVG line chart.
- Reuses the existing `VolumeChart` styling (grid lines, axis labels, emerald palette, `overflow-x-auto`) and is dark-mode aware.
- Single-point series render as a lone point with a "sparse" hint instead of a line.
- All copy localized for ja and en.

## Behavior

- Only exercises with recorded sets appear in the selector (intentional — keeps the chart focused on lifts you actually do).
- 1-session exercise → selectable, shows the sparse hint.
- No exercises with data → section empty state.

## Acceptance criteria

- [x] User can select an exercise and view its progression over time.
- [x] The line chart renders with axis labels and is dark-mode aware.
- [x] Sparse / single-point data renders sensibly.
- [x] Copy is localized for ja and en.

## Testing

- `npm run lint` — clean
- `npm run build` (incl. TypeScript) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
