### PR TITLE
feat: add milestones and achievement badges

### DIFF
--- a/src/app/[lang]/(workout)/workouts/stats/BadgeCollection.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/BadgeCollection.tsx
@@ -75,7 +75,10 @@ export default function BadgeCollection({ progress, next, lang, dict }: Props) {
               <span className="text-2xl" aria-hidden>
                 {entry.unlocked ? AXIS_ICONS[entry.axis] : '🔒'}
               </span>
-              <span className="text-xs font-medium text-zinc-900 dark:text-zinc-50">{name}</span>
+              <span className="text-xs font-medium text-zinc-900 dark:text-zinc-50">
+                {!entry.unlocked && <span className="sr-only">{dict.lockedLabel}: </span>}
+                {name}
+              </span>
               {!entry.unlocked && (
                 <span className="text-[10px] tabular-nums text-zinc-500 dark:text-zinc-400">
                   {translate(lang, dict.axes[entry.axis].progress, values)}

--- a/src/app/[lang]/(workout)/workouts/stats/BadgeCollection.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/BadgeCollection.tsx
@@ -1,0 +1,90 @@
+import type { Locale } from '@/i18n/config';
+import { formatNumber, translate } from '@/i18n/format';
+import type { Dictionary } from '@/i18n/getDictionary';
+import type { MilestoneAxis, MilestoneProgress } from './aggregate';
+
+const AXIS_ICONS: Record<MilestoneAxis, string> = {
+  workoutCount: '🏋️',
+  totalSets: '🔁',
+  totalVolume: '⚖️',
+  maxWeight: '💪',
+  streakDays: '🔥',
+};
+
+type Props = {
+  progress: MilestoneProgress[];
+  next: MilestoneProgress | null;
+  lang: Locale;
+  dict: Dictionary['stats']['badges'];
+};
+
+export default function BadgeCollection({ progress, next, lang, dict }: Props) {
+  const unlockedCount = progress.filter((entry) => entry.unlocked).length;
+
+  const templateValues = (entry: MilestoneProgress) => ({
+    threshold:
+      entry.axis === 'workoutCount' ? entry.threshold : formatNumber(lang, entry.threshold),
+    current: formatNumber(lang, Math.round(entry.current)),
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+        {translate(lang, dict.unlockedSummary, {
+          unlocked: unlockedCount,
+          total: progress.length,
+        })}
+      </p>
+
+      {next ? (
+        <div className="flex flex-col gap-1.5">
+          <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-50">
+              {dict.nextHeading}: {translate(lang, dict.axes[next.axis].name, templateValues(next))}
+            </p>
+            <p className="text-xs tabular-nums text-zinc-500 dark:text-zinc-400">
+              {translate(lang, dict.axes[next.axis].progress, templateValues(next))}
+            </p>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+            <div
+              className="h-full rounded-full bg-emerald-500"
+              style={{ width: `${Math.round(next.ratio * 100)}%` }}
+            />
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-emerald-600 dark:text-emerald-400">{dict.allUnlocked}</p>
+      )}
+
+      <ul className="grid grid-cols-3 gap-3 sm:grid-cols-5">
+        {progress.map((entry) => {
+          const values = templateValues(entry);
+          const name = translate(lang, dict.axes[entry.axis].name, values);
+          const description = translate(lang, dict.axes[entry.axis].description, values);
+          return (
+            <li
+              key={`${entry.axis}-${entry.threshold}`}
+              title={description}
+              className={`flex flex-col items-center gap-1 rounded-xl border p-3 text-center ${
+                entry.unlocked
+                  ? 'border-amber-200 bg-amber-50 dark:border-amber-900/50 dark:bg-amber-950/30'
+                  : 'border-black/[.08] bg-zinc-50 opacity-60 grayscale dark:border-white/[.145] dark:bg-zinc-950'
+              }`}
+            >
+              <span className="text-2xl" aria-hidden>
+                {entry.unlocked ? AXIS_ICONS[entry.axis] : '🔒'}
+              </span>
+              <span className="text-xs font-medium text-zinc-900 dark:text-zinc-50">{name}</span>
+              {!entry.unlocked && (
+                <span className="text-[10px] tabular-nums text-zinc-500 dark:text-zinc-400">
+                  {translate(lang, dict.axes[entry.axis].progress, values)}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
+++ b/src/app/[lang]/(workout)/workouts/stats/aggregate.ts
@@ -51,6 +51,33 @@ export type ExerciseProgression = {
   points: ProgressionPoint[];
 };
 
+export const MILESTONE_AXES = [
+  'workoutCount',
+  'totalSets',
+  'totalVolume',
+  'maxWeight',
+  'streakDays',
+] as const;
+export type MilestoneAxis = (typeof MILESTONE_AXES)[number];
+
+export const MILESTONE_THRESHOLDS: Record<MilestoneAxis, readonly number[]> = {
+  workoutCount: [1, 10, 50, 100, 250],
+  totalSets: [50, 250, 1000, 2500, 5000],
+  totalVolume: [10000, 50000, 250000, 1000000, 5000000],
+  maxWeight: [40, 60, 80, 100, 140],
+  streakDays: [3, 5, 7, 14, 30],
+};
+
+export type MilestoneStats = Record<MilestoneAxis, number>;
+
+export type MilestoneProgress = {
+  axis: MilestoneAxis;
+  threshold: number;
+  unlocked: boolean;
+  current: number;
+  ratio: number;
+};
+
 function toLocalDateKey(iso: string): string {
   const date = new Date(iso);
   const year = date.getFullYear();
@@ -194,4 +221,81 @@ export function buildExerciseProgressions(
   }
 
   return result.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function nextDateKey(key: string): string {
+  const [year, month, day] = key.split('-').map(Number);
+  const date = new Date(year!, month! - 1, day!);
+  date.setDate(date.getDate() + 1);
+  const nextYear = date.getFullYear();
+  const nextMonth = String(date.getMonth() + 1).padStart(2, '0');
+  const nextDay = String(date.getDate()).padStart(2, '0');
+  return `${nextYear}-${nextMonth}-${nextDay}`;
+}
+
+function computeLongestStreak(workouts: Workout[]): number {
+  const dateKeys = new Set<string>();
+  for (const workout of workouts) {
+    if (!workout.startedAt) continue;
+    dateKeys.add(toLocalDateKey(workout.startedAt));
+  }
+
+  const sorted = [...dateKeys].sort();
+  let longest = 0;
+  let current = 0;
+  let previous: string | null = null;
+  for (const key of sorted) {
+    current = previous !== null && nextDateKey(previous) === key ? current + 1 : 1;
+    longest = Math.max(longest, current);
+    previous = key;
+  }
+  return longest;
+}
+
+export function buildMilestoneStats(entries: { workout: Workout; sets: Set[] }[]): MilestoneStats {
+  let totalSets = 0;
+  let totalVolume = 0;
+  let maxWeight = 0;
+  for (const { sets } of entries) {
+    totalSets += sets.length;
+    totalVolume += computeWorkoutVolume(sets);
+    for (const set of sets) {
+      maxWeight = Math.max(maxWeight, set.weight ?? 0);
+    }
+  }
+
+  return {
+    workoutCount: entries.length,
+    totalSets,
+    totalVolume,
+    maxWeight,
+    streakDays: computeLongestStreak(entries.map(({ workout }) => workout)),
+  };
+}
+
+export function buildMilestoneProgress(stats: MilestoneStats): MilestoneProgress[] {
+  const result: MilestoneProgress[] = [];
+  for (const axis of MILESTONE_AXES) {
+    const current = stats[axis];
+    for (const threshold of MILESTONE_THRESHOLDS[axis]) {
+      result.push({
+        axis,
+        threshold,
+        unlocked: current >= threshold,
+        current,
+        ratio: Math.min(current / threshold, 1),
+      });
+    }
+  }
+  return result;
+}
+
+export function findNextMilestone(progress: MilestoneProgress[]): MilestoneProgress | null {
+  let next: MilestoneProgress | null = null;
+  for (const axis of MILESTONE_AXES) {
+    const candidate = progress.find((entry) => entry.axis === axis && !entry.unlocked);
+    if (!candidate) continue;
+    if (next === null || candidate.ratio > next.ratio) next = candidate;
+  }
+  return next;
 }

--- a/src/app/[lang]/(workout)/workouts/stats/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/stats/page.tsx
@@ -9,6 +9,7 @@ import { notFound } from 'next/navigation';
 import type { components as exerciseSchema } from '../../../../../../gen/exercise/v1/exercise.schema';
 import type { components as workoutSchema } from '../../../../../../gen/workout/v1/workout.schema';
 import ActivityHeatmap from './ActivityHeatmap';
+import BadgeCollection from './BadgeCollection';
 import BodyMap from './BodyMap';
 import ExerciseProgressChart from './ExerciseProgressChart';
 import LifetimeVolumeCard from './LifetimeVolumeCard';
@@ -16,8 +17,11 @@ import VolumeChart from './VolumeChart';
 import {
   buildDailyCounts,
   buildExerciseProgressions,
+  buildMilestoneProgress,
+  buildMilestoneStats,
   buildMuscleBalanceByPeriod,
   buildWorkoutVolumes,
+  findNextMilestone,
 } from './aggregate';
 
 type Workout = workoutSchema['schemas']['v1Workout'];
@@ -111,6 +115,8 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
   const exerciseProgressions = buildExerciseProgressions(detailEntries, exerciseById);
   const muscleBalance = buildMuscleBalanceByPeriod(detailEntries, exerciseById, new Date());
   const lifetimeVolume = workoutVolumes.reduce((sum, w) => sum + w.volume, 0);
+  const milestoneProgress = buildMilestoneProgress(buildMilestoneStats(detailEntries));
+  const nextMilestone = findNextMilestone(milestoneProgress);
   const detailFailures = detailResults.filter(({ result }) => !!result.error).length;
   const exercisesFailed = !!exercisesResult.error;
 
@@ -134,6 +140,21 @@ export default async function WorkoutStatsPage({ params }: { params: Promise<{ l
         ) : (
           <>
             <LifetimeVolumeCard total={lifetimeVolume} lang={lang} dict={t.lifetimeVolume} />
+
+            <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
+              <h2 className="mb-4 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">
+                {t.badges.heading}
+              </h2>
+              {detailFailures > 0 && (
+                <p className="mb-3 text-xs text-rose-500">{t.detailPartialFailure}</p>
+              )}
+              <BadgeCollection
+                progress={milestoneProgress}
+                next={nextMilestone}
+                lang={lang}
+                dict={t.badges}
+              />
+            </section>
 
             <section className="rounded-2xl border border-black/[.08] bg-white p-4 sm:p-5 dark:border-white/[.145] dark:bg-zinc-900">
               <h2 className="mb-4 text-base font-semibold text-zinc-900 sm:text-lg dark:text-zinc-50">

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -109,6 +109,40 @@
         "jumboJet": "{count, plural, one {# jumbo jet} other {# jumbo jets}}"
       }
     },
+    "badges": {
+      "heading": "Badges",
+      "unlockedSummary": "{unlocked} / {total} unlocked",
+      "nextHeading": "Next milestone",
+      "allUnlocked": "All badges unlocked!",
+      "lockedLabel": "Locked",
+      "axes": {
+        "workoutCount": {
+          "name": "{threshold, plural, =1 {First workout} other {# workouts}}",
+          "description": "Complete {threshold, plural, =1 {your first workout} other {# workouts}}",
+          "progress": "{current} / {threshold} workouts"
+        },
+        "totalSets": {
+          "name": "{threshold} sets",
+          "description": "Log {threshold} sets in total",
+          "progress": "{current} / {threshold} sets"
+        },
+        "totalVolume": {
+          "name": "{threshold} kg lifted",
+          "description": "Lift {threshold} kg of total volume",
+          "progress": "{current} / {threshold} kg"
+        },
+        "maxWeight": {
+          "name": "{threshold} kg club",
+          "description": "Lift {threshold} kg in a single set",
+          "progress": "{current} / {threshold} kg"
+        },
+        "streakDays": {
+          "name": "{threshold}-day streak",
+          "description": "Work out {threshold} days in a row",
+          "progress": "{current} / {threshold} days"
+        }
+      }
+    },
     "heatmap": {
       "summary": "{total, plural, one {# workout} other {# workouts}} on {days, plural, one {# day} other {# days}} (last {weeks} weeks)",
       "noActivity": "No workout activity yet.",

--- a/src/i18n/dictionaries/ja.json
+++ b/src/i18n/dictionaries/ja.json
@@ -109,6 +109,40 @@
         "jumboJet": "ジャンボジェット {count} 機分"
       }
     },
+    "badges": {
+      "heading": "実績バッジ",
+      "unlockedSummary": "{unlocked} / {total} 解除",
+      "nextHeading": "次のマイルストーン",
+      "allUnlocked": "すべてのバッジを解除しました！",
+      "lockedLabel": "未解除",
+      "axes": {
+        "workoutCount": {
+          "name": "{threshold, plural, =1 {はじめてのワークアウト} other {ワークアウト # 回}}",
+          "description": "ワークアウトを {threshold} 回完了する",
+          "progress": "{current} / {threshold} 回"
+        },
+        "totalSets": {
+          "name": "累計 {threshold} セット",
+          "description": "累計 {threshold} セットを記録する",
+          "progress": "{current} / {threshold} セット"
+        },
+        "totalVolume": {
+          "name": "総ボリューム {threshold} kg",
+          "description": "累計 {threshold} kg を持ち上げる",
+          "progress": "{current} / {threshold} kg"
+        },
+        "maxWeight": {
+          "name": "{threshold} kg クラブ",
+          "description": "1 セットで {threshold} kg を挙げる",
+          "progress": "{current} / {threshold} kg"
+        },
+        "streakDays": {
+          "name": "{threshold} 日ストリーク",
+          "description": "{threshold} 日連続でワークアウトする",
+          "progress": "{current} / {threshold} 日"
+        }
+      }
+    },
     "heatmap": {
       "summary": "直近 {weeks} 週間で {days} 日に {total} 回のワークアウト",
       "noActivity": "まだワークアウトのアクティビティがありません。",


### PR DESCRIPTION
## Summary

Adds **milestones and achievement badges** that users unlock as they train, displayed as a new section on the stats page. Closes #28.

- New aggregates in `aggregate.ts`: `buildMilestoneStats` computes per-axis totals (workout count, total sets, total volume, max weight, longest day streak), `buildMilestoneProgress` derives unlock state and progress ratio for each milestone, and `findNextMilestone` picks the closest locked one.
- 25 milestones: 5 axes × 5 thresholds, defined declaratively in `MILESTONE_THRESHOLDS` so tiers can be tuned without touching logic or copy.
- New `BadgeCollection` server component: unlocked summary count, next-milestone progress bar, and a badge grid where unlocked badges show an emoji icon on an amber card and locked ones are grayscale with a 🔒 and progress text.
- Streaks count distinct local calendar days (multiple workouts on one day count once) and the consecutive-day check is DST-safe.
- All copy localized for ja and en via threshold-interpolated templates, with an `=1` plural case for the special "First workout" badge name.

## Behavior

- Badge section reuses the data already fetched by the stats page; partial workout-detail failures show the existing warning and compute from what loaded.
- No workouts → the existing stats empty state, no badge section.
- Bodyweight sets (no weight) count toward sets/workouts but not volume or max weight; workouts without `startedAt` count toward totals but not streaks.
- All milestones unlocked → the progress bar is replaced by an "all unlocked" message.

## Acceptance criteria

- [x] Milestone definitions exist and unlock states are computed correctly from history.
- [x] A badge collection with locked/unlocked states is displayed.
- [x] The next milestone and progress toward it are surfaced.
- [x] Copy is localized for ja and en.

## Testing

- `npm run lint` — clean
- `npm run build` (incl. TypeScript) — passes
- Aggregation helpers exercised manually against fixture data (streak dedup across same-day workouts, missing `startedAt`, bodyweight sets, empty history, all-unlocked, DST boundary)
- Dictionary templates verified through `translate()` for both locales (incl. `=1` plural and `formatNumber` for large thresholds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)