### PR TITLE
feat: show workout completion summary card on finish (#29)

### DIFF
--- a/src/app/[lang]/(workout)/workouts/[workoutId]/WorkoutSummaryModal.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/WorkoutSummaryModal.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import type { Locale } from '@/i18n/config';
+import { formatNumber, translate } from '@/i18n/format';
+import type { Dictionary } from '@/i18n/getDictionary';
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { durationParts, type WorkoutSummary } from './summary';
+
+type SummaryDict = Dictionary['workoutDetail']['summary'];
+
+const CONFETTI_PIECES = [
+  { className: 'left-[4%] bg-amber-500', delay: '0s', duration: '2.5s' },
+  { className: 'left-[12%] bg-emerald-500', delay: '0.4s', duration: '2.9s' },
+  { className: 'left-[20%] bg-sky-500', delay: '0.1s', duration: '2.3s' },
+  { className: 'left-[28%] bg-rose-500', delay: '0.6s', duration: '2.7s' },
+  { className: 'left-[36%] bg-purple-500', delay: '0.2s', duration: '2.4s' },
+  { className: 'left-[44%] bg-amber-500', delay: '0.5s', duration: '3s' },
+  { className: 'left-[52%] bg-emerald-500', delay: '0s', duration: '2.6s' },
+  { className: 'left-[60%] bg-rose-500', delay: '0.3s', duration: '2.2s' },
+  { className: 'left-[68%] bg-sky-500', delay: '0.7s', duration: '2.8s' },
+  { className: 'left-[76%] bg-purple-500', delay: '0.1s', duration: '2.5s' },
+  { className: 'left-[84%] bg-amber-500', delay: '0.4s', duration: '2.3s' },
+  { className: 'left-[92%] bg-emerald-500', delay: '0.2s', duration: '2.9s' },
+  { className: 'left-[16%] bg-rose-500', delay: '0.9s', duration: '2.6s' },
+  { className: 'left-[48%] bg-sky-500', delay: '1.1s', duration: '2.4s' },
+  { className: 'left-[80%] bg-purple-500', delay: '0.8s', duration: '2.7s' },
+];
+
+function formatDuration(
+  lang: Locale,
+  dict: SummaryDict,
+  durationMs: number | undefined,
+  unknownLabel: string,
+): string {
+  if (durationMs === undefined) return unknownLabel;
+  const { hours, minutes } = durationParts(durationMs);
+  return hours > 0
+    ? translate(lang, dict.durationHoursMinutes, { hours, minutes })
+    : translate(lang, dict.durationMinutes, { minutes });
+}
+
+export default function WorkoutSummaryModal({
+  lang,
+  summary,
+  dict,
+  kgUnit,
+  unknownLabel,
+  prLabels,
+}: {
+  lang: Locale;
+  summary: WorkoutSummary;
+  dict: SummaryDict;
+  kgUnit: string;
+  unknownLabel: string;
+  prLabels: { weight: string; volume: string };
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') router.replace(pathname, { scroll: false });
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [router, pathname]);
+
+  const close = () => router.replace(pathname, { scroll: false });
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) close();
+      }}
+    >
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
+        {CONFETTI_PIECES.map((piece, index) => (
+          <span
+            key={index}
+            className={`absolute -top-4 h-3 w-2 rounded-[1px] opacity-0 motion-safe:animate-confetti-fall ${piece.className}`}
+            style={{ animationDelay: piece.delay, animationDuration: piece.duration }}
+          />
+        ))}
+      </div>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="workout-summary-title"
+        className="relative flex w-full max-w-md flex-col gap-5 rounded-2xl border border-black/[.08] bg-white p-6 motion-safe:animate-summary-pop-in dark:border-white/[.145] dark:bg-zinc-900"
+      >
+        <h2
+          id="workout-summary-title"
+          className="text-center text-xl font-semibold text-zinc-900 dark:text-zinc-50"
+        >
+          🎉 {dict.title}
+        </h2>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt className="text-zinc-500 dark:text-zinc-400">{dict.durationLabel}</dt>
+          <dd className="text-right font-medium text-zinc-900 dark:text-zinc-50">
+            {formatDuration(lang, dict, summary.durationMs, unknownLabel)}
+          </dd>
+          <dt className="text-zinc-500 dark:text-zinc-400">{dict.setsLabel}</dt>
+          <dd className="text-right font-medium text-zinc-900 dark:text-zinc-50">
+            {translate(lang, dict.setsValue, { count: summary.totalSets })}
+          </dd>
+          <dt className="text-zinc-500 dark:text-zinc-400">{dict.volumeLabel}</dt>
+          <dd className="text-right font-medium text-zinc-900 dark:text-zinc-50">
+            {translate(lang, dict.volumeValue, {
+              volume: formatNumber(lang, summary.totalVolume),
+              unit: kgUnit,
+            })}
+          </dd>
+        </dl>
+        {summary.prs.length > 0 ? (
+          <div className="rounded-xl bg-amber-50 p-3 dark:bg-amber-500/10">
+            <h3 className="mb-2 text-sm font-semibold text-amber-800 dark:text-amber-300">
+              {dict.prHeading}
+            </h3>
+            <ul className="flex flex-col gap-1 text-sm">
+              {summary.prs.map((pr) => (
+                <li key={pr.name} className="flex items-center justify-between gap-2">
+                  <span className="min-w-0 flex-1 text-zinc-900 dark:text-zinc-50">{pr.name}</span>
+                  <span className="flex shrink-0 items-center gap-0.5 leading-none">
+                    {pr.weight && (
+                      <span
+                        role="img"
+                        aria-label={prLabels.weight}
+                        title={prLabels.weight}
+                        className="text-base"
+                      >
+                        👑
+                      </span>
+                    )}
+                    {pr.volume && (
+                      <span
+                        role="img"
+                        aria-label={prLabels.volume}
+                        title={prLabels.volume}
+                        className="text-base"
+                      >
+                        💪
+                      </span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <p className="text-center text-sm text-zinc-600 dark:text-zinc-400">{dict.prEmpty}</p>
+        )}
+        <button
+          type="button"
+          onClick={close}
+          className="inline-flex min-h-[44px] w-full items-center justify-center rounded-full bg-foreground py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
+        >
+          {dict.close}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/WorkoutSummaryModal.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/WorkoutSummaryModal.tsx
@@ -120,7 +120,7 @@ export default function WorkoutSummaryModal({
             </h3>
             <ul className="flex flex-col gap-1 text-sm">
               {summary.prs.map((pr) => (
-                <li key={pr.name} className="flex items-center justify-between gap-2">
+                <li key={pr.exerciseId} className="flex items-center justify-between gap-2">
                   <span className="min-w-0 flex-1 text-zinc-900 dark:text-zinc-50">{pr.name}</span>
                   <span className="flex shrink-0 items-center gap-0.5 leading-none">
                     {pr.weight && (

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/actions.ts
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/actions.ts
@@ -119,5 +119,5 @@ export async function finishWorkout(lang: string, workoutId: string) {
 
   revalidatePath(`/workouts/${workoutId}`);
   revalidatePath('/workouts');
-  redirect(`${prefix}/workouts`);
+  redirect(`${prefix}/workouts/${workoutId}?finished=1`);
 }

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/page.tsx
@@ -13,8 +13,10 @@ import { notFound } from 'next/navigation';
 import type { components as exerciseSchema } from '../../../../../../gen/exercise/v1/exercise.schema';
 import type { components as workoutSchema } from '../../../../../../gen/workout/v1/workout.schema';
 import AddSetForm from './AddSetForm';
+import WorkoutSummaryModal from './WorkoutSummaryModal';
 import { finishWorkout } from './actions';
 import { computePrFlags } from './records';
+import { buildWorkoutSummary } from './summary';
 
 type Workout = workoutSchema['schemas']['v1Workout'];
 type Set = workoutSchema['schemas']['v1Set'];
@@ -36,13 +38,13 @@ export default async function WorkoutDetailPage({
   searchParams,
 }: {
   params: Promise<{ lang: string; workoutId: string }>;
-  searchParams: Promise<{ error?: string }>;
+  searchParams: Promise<{ error?: string; finished?: string }>;
 }) {
   const { lang, workoutId } = await params;
   if (!isLocale(lang)) notFound();
   const dict = await getDictionary(lang);
   const t = dict.workoutDetail;
-  const { error: errorParam } = await searchParams;
+  const { error: errorParam, finished: finishedParam } = await searchParams;
 
   const accessToken = await getAccessToken();
   if (!accessToken) {
@@ -101,6 +103,7 @@ export default async function WorkoutDetailPage({
   );
   const prFlagsById = computePrFlags(allSetsResult.sets);
   const isFinished = !!workout.finishedAt;
+  const showSummary = finishedParam === '1' && isFinished;
 
   const boundFinish = finishWorkout.bind(null, lang, workoutId);
 
@@ -233,6 +236,17 @@ export default async function WorkoutDetailPage({
           </form>
         )}
       </div>
+
+      {showSummary && (
+        <WorkoutSummaryModal
+          lang={lang}
+          summary={buildWorkoutSummary(workout, sets, prFlagsById, exerciseById)}
+          dict={t.summary}
+          kgUnit={dict.units.kg}
+          unknownLabel={dict.common.unknown}
+          prLabels={{ weight: t.prBadgeWeight, volume: t.prBadgeVolume }}
+        />
+      )}
     </main>
   );
 }

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/summary.ts
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/summary.ts
@@ -1,0 +1,72 @@
+import type { components as exerciseSchema } from '../../../../../../gen/exercise/v1/exercise.schema';
+import type { components as workoutSchema } from '../../../../../../gen/workout/v1/workout.schema';
+import { computeWorkoutVolume } from '../stats/aggregate';
+import type { PrFlags } from './records';
+
+type Workout = workoutSchema['schemas']['v1Workout'];
+type Set = workoutSchema['schemas']['v1Set'];
+type Exercise = exerciseSchema['schemas']['v1Exercise'];
+
+export type PrSummaryEntry = {
+  name: string;
+  weight: boolean;
+  volume: boolean;
+};
+
+export type WorkoutSummary = {
+  durationMs?: number;
+  totalSets: number;
+  totalVolume: number;
+  prs: PrSummaryEntry[];
+};
+
+function parseTime(value?: string): number | undefined {
+  if (!value) return undefined;
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? undefined : time;
+}
+
+export function buildWorkoutSummary(
+  workout: Workout,
+  sets: Set[],
+  prFlagsById: Map<string, PrFlags>,
+  exerciseById: Map<string, Exercise>,
+): WorkoutSummary {
+  const started = parseTime(workout.startedAt);
+  const finished = parseTime(workout.finishedAt);
+  const durationMs =
+    started !== undefined && finished !== undefined && finished >= started
+      ? finished - started
+      : undefined;
+
+  const prByExercise = new Map<string, PrSummaryEntry>();
+  for (const set of sets) {
+    if (!set.setId || !set.exerciseId) continue;
+    const flags = prFlagsById.get(set.setId);
+    if (!flags) continue;
+    const entry = prByExercise.get(set.exerciseId);
+    if (entry) {
+      entry.weight = entry.weight || flags.weight;
+      entry.volume = entry.volume || flags.volume;
+    } else {
+      const exercise = exerciseById.get(set.exerciseId);
+      prByExercise.set(set.exerciseId, {
+        name: exercise?.name ?? exercise?.code ?? set.exerciseId,
+        weight: flags.weight,
+        volume: flags.volume,
+      });
+    }
+  }
+
+  return {
+    durationMs,
+    totalSets: sets.length,
+    totalVolume: computeWorkoutVolume(sets),
+    prs: [...prByExercise.values()],
+  };
+}
+
+export function durationParts(ms: number): { hours: number; minutes: number } {
+  const totalMinutes = Math.floor(ms / 60000);
+  return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 };
+}

--- a/src/app/[lang]/(workout)/workouts/[workoutId]/summary.ts
+++ b/src/app/[lang]/(workout)/workouts/[workoutId]/summary.ts
@@ -8,6 +8,7 @@ type Set = workoutSchema['schemas']['v1Set'];
 type Exercise = exerciseSchema['schemas']['v1Exercise'];
 
 export type PrSummaryEntry = {
+  exerciseId: string;
   name: string;
   weight: boolean;
   volume: boolean;
@@ -51,6 +52,7 @@ export function buildWorkoutSummary(
     } else {
       const exercise = exerciseById.get(set.exerciseId);
       prByExercise.set(set.exerciseId, {
+        exerciseId: set.exerciseId,
         name: exercise?.name ?? exercise?.code ?? set.exerciseId,
         weight: flags.weight,
         volume: flags.volume,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,40 @@
   }
 }
 
+@theme {
+  --animate-summary-pop-in: summary-pop-in 0.35s cubic-bezier(0.22, 1.2, 0.36, 1) both;
+  --animate-confetti-fall: confetti-fall 2.6s linear forwards;
+
+  @keyframes summary-pop-in {
+    from {
+      opacity: 0;
+      transform: scale(0.85) translateY(12px);
+    }
+    60% {
+      opacity: 1;
+      transform: scale(1.03) translateY(0);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1) translateY(0);
+    }
+  }
+
+  @keyframes confetti-fall {
+    0% {
+      opacity: 1;
+      transform: translateY(0) rotate(0deg);
+    }
+    80% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(110vh) rotate(720deg);
+    }
+  }
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -61,7 +61,20 @@
     "finishFailed": "Failed to finish workout. Please try again.",
     "loadExercisesFailed": "Failed to load exercises.",
     "prBadgeWeight": "Personal best (weight)",
-    "prBadgeVolume": "Personal best (volume)"
+    "prBadgeVolume": "Personal best (volume)",
+    "summary": {
+      "title": "Workout complete!",
+      "durationLabel": "Duration",
+      "durationHoursMinutes": "{hours}h {minutes}m",
+      "durationMinutes": "{minutes}m",
+      "setsLabel": "Total sets",
+      "setsValue": "{count, plural, one {# set} other {# sets}}",
+      "volumeLabel": "Total volume",
+      "volumeValue": "{volume} {unit}",
+      "prHeading": "Personal records",
+      "prEmpty": "No new records this time — keep pushing!",
+      "close": "Close"
+    }
   },
   "addSet": {
     "exercise": "Exercise",

--- a/src/i18n/dictionaries/ja.json
+++ b/src/i18n/dictionaries/ja.json
@@ -61,7 +61,20 @@
     "finishFailed": "ワークアウトの終了に失敗しました。もう一度お試しください。",
     "loadExercisesFailed": "種目の読み込みに失敗しました。",
     "prBadgeWeight": "自己ベスト（重量）",
-    "prBadgeVolume": "自己ベスト（ボリューム）"
+    "prBadgeVolume": "自己ベスト（ボリューム）",
+    "summary": {
+      "title": "ワークアウト完了！",
+      "durationLabel": "所要時間",
+      "durationHoursMinutes": "{hours}時間{minutes}分",
+      "durationMinutes": "{minutes}分",
+      "setsLabel": "総セット数",
+      "setsValue": "{count} セット",
+      "volumeLabel": "総ボリューム",
+      "volumeValue": "{volume} {unit}",
+      "prHeading": "自己ベスト更新",
+      "prEmpty": "今回は記録更新なし。次回に期待！",
+      "close": "閉じる"
+    }
   },
   "addSet": {
     "exercise": "種目",


### PR DESCRIPTION
## Summary

Closes #29

- Redirect to the workout detail page with `?finished=1` after finishing a workout, instead of returning quietly to the list.
- Show a celebratory summary modal with session duration (`finishedAt − startedAt`), total sets, total volume, and personal records set during the session (exercise name with 👑 weight / 💪 volume badges, reusing `computePrFlags` and `computeWorkoutVolume`).
- Celebratory treatment in CSS only (no new dependencies): card pop-in and falling confetti, defined as Tailwind v4 `@theme` animation tokens and applied via `motion-safe:` so reduced-motion users get a static card.
- Dark-mode aware, localized for ja/en.
- The modal closes via button, backdrop click, or Escape; closing strips `?finished=1` with `router.replace` so it does not reappear on reload or history navigation.

Out of scope (stretch in the issue): shareable image generation.

## Notes

- Guarded server-side: the modal only renders when the workout is actually finished, so hand-typing `?finished=1` on an in-progress workout shows nothing.
- Confetti pieces are a fixed literal array — keeps SSR hydration deterministic and lets Tailwind statically generate the utility classes.

## Test plan

- [x] `tsc --noEmit`, `eslint`, `next build` pass
- [x] Generated CSS verified to contain the keyframes and `motion-safe:animate-*` utilities
- [ ] Manual check with local backend: finish a workout → modal shows duration / sets / volume / PRs; close via button, backdrop, and Escape; ja & en; dark mode; zero-set workout

🤖 Generated with [Claude Code](https://claude.com/claude-code)